### PR TITLE
Prevents custom post types from being published to Discourse (if needed)

### DIFF
--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -174,9 +174,26 @@ class Discourse {
 
   function publish_post_to_discourse($postid){
     $post = get_post($postid);
-    if (get_post_status($postid) == "publish" && get_post_meta($postid, 'publish_to_discourse', true)) {
+    if (get_post_status($postid) == "publish" && get_post_meta($postid, 'publish_to_discourse', true) && !is_custom_post_type($postid)) {
       self::sync_to_discourse($postid, $post->post_title, $post->post_content);
     }
+  }
+  
+  function is_custom_post_type( $post = NULL ){
+    $all_custom_post_types = get_post_types( array ( '_builtin' => FALSE ) );
+
+    // there are no custom post types
+    if ( empty ( $all_custom_post_types ) )
+        return FALSE;
+
+    $custom_types      = array_keys( $all_custom_post_types );
+    $current_post_type = get_post_type( $post );
+
+    // could not detect current type
+    if ( ! $current_post_type )
+        return FALSE;
+
+    return in_array( $current_post_type, $custom_types );
   }
 
   function save_postdata($postid)


### PR DESCRIPTION
This forcibly prevents custom post types (for example, as used by some wordpress plugins) from being published to Discourse.

It's a little heavy-handed, because it essentially blocks _all_ custom posts from being published, which might actually be desired behaviour in some situations. 

It might also not be necessary, for example I just tried using the "Liveblogging" plugin without this fix, which didn't actually publish anything to Discourse even with the option checked, which may mean it's down to how the custom posts are implemented.

I leave it to someone with more wp plugin experience to chime in, and I'll do some additional testing.
