### PR TITLE
Added {thumbnail} and {featuredimage} template tags

### DIFF
--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -309,6 +309,10 @@ class Discourse {
     $author_id=$post->post_author;
     $author = get_the_author_meta( "display_name", $author_id );
     $baked = str_replace("{author}", $author, $baked);
+    $thumb = wp_get_attachment_image_src( get_post_thumbnail_id($postid), 'thumbnail' );
+    $baked = str_replace("{thumbnail}", "![image](".$thumb['0'].")", $baked);
+    $featured = wp_get_attachment_image_src( get_post_thumbnail_id($postid), 'full' );
+    $baked = str_replace("{featuredimage}", "![image](".$featured['0'].")", $baked);
 
     $username = get_the_author_meta('discourse_username', $post->post_author);
     if(!$username || strlen($username) < 2) {


### PR DESCRIPTION
Added two tags for use in the publish format template:
{thumbnail} grabs the featured image thumbnail for the post
{featuredimage} grabs the full-size featured image for the post

Note: Using {featuredimage} may or may not need to have "create_thumbnails" enabled in discourse for best results

An example of how this comes out can be seen here:

http://forums.ctrlcmdesc.com/t/costume-quest/298
