### PR TITLE
Removed timestamp call that required PHP 5.3

### DIFF
--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -128,7 +128,7 @@ class Discourse {
 
     # every 10 minutes do a json call to sync comment count and top comments
     $last_sync = (int)get_post_meta($postid, 'discourse_last_sync', true);
-    $time = date_timestamp_get(date_create());
+    $time = date_create()->format('U');
     $debug = isset($discourse_options['debug-mode']) && intval($discourse_options['debug-mode']) == 1;
     if($debug || $last_sync + 60 * 10 < $time) {
 


### PR DESCRIPTION
date_timestamp_get() requires PHP 5.3, which for some installations is not available.

The format replacement works in my setup under 5.2 and 5.3, but I've not tested it more widely than that.
