### PR TITLE
Replaced deprecated $wpdb->escape

### DIFF
--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -172,7 +172,7 @@ class Discourse {
 
           delete_post_meta($postid, 'discourse_comments_raw');
 
-          add_post_meta($postid, 'discourse_comments_raw', $wpdb->escape($result) , true);
+          add_post_meta($postid, 'discourse_comments_raw', esc_sql($result) , true);
 
           delete_post_meta($postid, 'discourse_last_sync');
           add_post_meta($postid, 'discourse_last_sync', $time, true);


### PR DESCRIPTION
$wpdb->escape has been deprecated and should be replaced with esc_sql to avoid notice messages in log file. 
https://www.webniraj.com/2013/08/05/wordpress-3-6-fixing-wpdbescape-deprecation-errors/
