### PR TITLE
Scheduled post support

### DIFF
--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -268,7 +268,8 @@ class Discourse {
 	}
 
 	function publish_post_to_discourse( $new_status, $old_status, $post ) {
-		if ( self::publish_active() && $new_status == 'publish' && $old_status != 'publish' && self::is_valid_sync_post_type( $post->ID ) ) {
+		$publish_to_discourse = get_post_meta( $post->ID, 'publish_to_discourse', true );
+		if ( ( self::publish_active() || ! empty( $publish_to_discourse ) ) && $new_status == 'publish' && $old_status != 'publish' && self::is_valid_sync_post_type( $post->ID ) ) {
 			// This seems a little redundant after `save_postdata` but when using the Press This
 			// widget it updates the field as it should.
 


### PR DESCRIPTION
Changed from `publish_post` to `transition_post_status` hook for determining if a post is published which should account for scheduled posts. I have not tested this out yet, but I think it should work.
