### PR TITLE
Slight improvement to scheduling posts

### DIFF
--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -173,7 +173,7 @@ class Discourse {
 					// if you have a scheduled post we never seem to be called
 					if( ! ( get_post_meta( $postid, 'discourse_post_id', true ) > 0 ) ) {
 						$post = get_post( $postid );
-						self::publish_post_to_discourse( 'publish', 'notpublish', $post );
+						self::publish_post_to_discourse( 'publish', 'publish', $post );
 					}
 
 					$comment_count = intval( $discourse_options['max-comments'] );
@@ -269,7 +269,7 @@ class Discourse {
 
 	function publish_post_to_discourse( $new_status, $old_status, $post ) {
 		$publish_to_discourse = get_post_meta( $post->ID, 'publish_to_discourse', true );
-		if ( ( self::publish_active() || ! empty( $publish_to_discourse ) ) && $new_status == 'publish' && $old_status != 'publish' && self::is_valid_sync_post_type( $post->ID ) ) {
+		if ( ( self::publish_active() || ! empty( $publish_to_discourse ) ) && $new_status == 'publish' && self::is_valid_sync_post_type( $post->ID ) ) {
 			// This seems a little redundant after `save_postdata` but when using the Press This
 			// widget it updates the field as it should.
 


### PR DESCRIPTION
I don't think the `$old_status` is needed. If we use the `transition_post_status` hook just to check for the `$new_status` to be `publish` that should be fine. That will then allow an unchecked "Publish to Discourse" box to be checked after the post is published and it will post to Discourse without needing to change the post status.

The reason the `$old_status` was being used is I thought that a post might get published to Discourse multiple times if you were to simply update the post, but that doesn't appear to be the case.
