### PR TITLE
Remove unnecessary stylesheet

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,1 +1,0 @@
-/* insert wp-discourse related styling here */

--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -164,9 +164,6 @@ class Discourse {
     add_filter( 'query_vars', array( $this, 'sso_add_query_vars' ) );
 
     $plugin_dir = plugin_dir_url( __FILE__ );
-    wp_register_style( 'discourse_comments', $plugin_dir . 'css/style.css' );
-    wp_enqueue_style( 'discourse_comments' );
-
     wp_register_script( 'discourse_comments_js', $plugin_dir . 'js/discourse.js', array( 'jquery' ));
     wp_enqueue_script( 'discourse_comments_js' );
 


### PR DESCRIPTION
This extra request is unnecessary. Not only was the stylesheet blank, but in a typical workflow you'd never want to edit files from a 3rd party plugin on your WP site. 

If there was going to be some default styling included, this file should stay. But if there's not going to be any included styles, then users will add styling to their WordPress theme instead of editing plugin files.