### PR TITLE
Resend: Publish to Discourse with WP Category

### DIFF
--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -542,6 +542,17 @@ class Discourse {
       $username = $options['publish-username'];
     }
 
+    $category = $options['publish-category'];
+    if ($category === '') {
+      $categories = get_the_category();
+      foreach($categories as $category) {
+        if ( in_category( $category->name, $postid ) ) {
+          $category = $category->name;
+          break;
+        }
+      }
+    }
+
     $data = array(
       'wp-id' => $postid,
       'embed_url' => get_permalink( $postid ),
@@ -549,7 +560,7 @@ class Discourse {
       'api_username' => $username,
       'title' => $title,
       'raw' => $baked,
-      'category' => $options['publish-category'],
+      'category' => $category,
       'skip_validations' => 'true',
       'auto_track' => ( $options['auto-track'] == "1" ? 'true' : 'false' )
     );


### PR DESCRIPTION
Origin: 9dc6085cf52bd02f96b52d8c2200f584e02b3e0e
Fix: #92

When “Published category ” setting is null, get the category of
Wordpress Article and post as publish-category to
Discourse.