### PR TITLE
Categories are now fetched from remote

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -223,8 +223,8 @@ class DiscourseAdmin {
 
     foreach( $categories as $category ){
       printf( '<option value="%s"%s>%s</option>',
-        $category['slug'],
-        selected( $options['publish-category'], $category['slug'], false ),
+        $category['id'],
+        selected( $options['publish-category'], $category['id'], false ),
         $category['name']
       );
     }


### PR DESCRIPTION
Categories are now fetched from remote, so instead of a text field, we will display a dropdown.

I'm not sure yet why empty categories are not displayed, but it's surely something on Discourse end...