### PR TITLE
Fixes for allowed post types

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -172,13 +172,13 @@ class DiscourseAdmin {
 
     foreach ( $post_types as $post_type ) {
 
-      if (array_key_exists( $option, $options) and in_array( $post_type, $options[$option] ) ) {
+      if ( array_key_exists( $option, $options) and in_array( $post_type, $options[$option] ) ) {
         $value = 'selected';
       } else {
         $value = '';
       }
 
-      echo "<option ".$value." value='".$post_type."''>".$post_type."</option>";
+      echo "<option ".$value." value='".$post_type."'>".$post_type."</option>";
     }
 
     echo '</select>';

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -342,7 +342,8 @@ class Discourse {
   }
 
   function get_allowed_post_types() {
-    $selected_post_types = get_option( 'discourse_allowed_post_types' );
+    $discourse_options = self::get_plugin_options();
+    $selected_post_types = $discourse_options['allowed_post_types'];
 
     /** If no post type is explicitly set then use the defaults */
     if ( empty( $selected_post_types ) ) {


### PR DESCRIPTION
1. Removed a redundant single quotation mark.
2. Updated to get the discourse options from allowed_post_types