### PR TITLE
Fix comment img urls

### DIFF
--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -204,7 +204,7 @@ class Discourse {
   }
 
   static function convert_relative_img_src_to_absolute($url, $content) {
-    $search = '#<img src="((?!\s*[\'"]?(?:https?:)?//)\s*([\'"]))?#';
+    $search = '#<img src="((?!\s*[\'"]?(?:https?:)?\/\/)\s*([\'"]))?#';
     $replace = "<img src=\"{$url}$1";
     return preg_replace($search, $replace, $content);
   }

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -204,6 +204,9 @@ class Discourse {
   }
 
   static function convert_relative_img_src_to_absolute($url, $content) {
+    if( preg_match( "/<img\s*src\s*=\s*[\'\"]?(https?:)?\/\//i", $content) )
+      return $content;
+
     $search = '#<img src="((?!\s*[\'"]?(?:https?:)?\/\/)\s*([\'"]))?#';
     $replace = "<img src=\"{$url}$1";
     return preg_replace($search, $replace, $content);


### PR DESCRIPTION
A previous PR #114 (see also context in #113) added a function to convert relative img src URLs to absolute. Unfortunately, for me, it also turned already absolute URLs into *absoluter* ones, which broke them.

![2015-04-04 at 8 34 am](https://cloud.githubusercontent.com/assets/327716/6992906/c26eaa7a-daa7-11e4-9cd4-0d884550f672.png)

I added a test to the function to see if the URL was already absolute and if so, not do any conversion.

While I was at it, I tweaked the original search regex to escape a couple of naked forward slashes, which I think was wrong. On my setup (using Discourse version 1.3.0.beta4), media URL's in comments are already coming over as absolute, so I cannot directly test that this still correctly converts relative URLs to absolute, but I think it should.