### PR TITLE
use proper current user function

### DIFF
--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -173,8 +173,7 @@ class Discourse {
         $nonce = $sso->getNonce( $payload );
 
         // Current user info
-        global $current_user;
-        get_currentuserinfo();
+        $current_user = wp_get_current_user();
 
         // Map information
         $params = array(


### PR DESCRIPTION
replace call to 'get_currentuserinfo()' with call to wp_get_current_user()

I'm not sure why `get_currentuserinfo()` doesn't work and replacing it with a wrapper for it `wp_get_current_user()` does work in this case, but this fixes #115 for me.

The source for the change was comparing the SSO callback in wp-discourse which was not working for me with the SSO callback in [PrimeTime WP Discourse SSO](https://wordpress.org/plugins/pt-wp-discourse-sso/) which was.