### PR TITLE
add <time> tag to WP allowed html tags

### DIFF
--- a/templates/comments.php
+++ b/templates/comments.php
@@ -18,6 +18,10 @@ $defaults = array(
   'participants' => array()
 );
 
+// add <time> tag to WP allowed html tags
+global $allowedposttags;
+$allowedposttags['time'] = array('datetime'=>array());
+
 // Add some protection in the event our metadata doesn't look how we expect it to
 $discourse_info = (object)wp_parse_args((array)$discourse_info, $defaults);
 


### PR DESCRIPTION
wordpress was stripping out the <time> tag from the discourse comment html resulting in the date-time meta html not being formatted correctly. this patch just allows the <time> tag to be included in the comment html.

![2015-04-21 at 9 18 am](https://cloud.githubusercontent.com/assets/327716/7254259/8540debc-e807-11e4-9fad-48128bdd8e0c.png)
