### PR TITLE
add custom datetime format string to admin settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ This WordPress plugin allows you to **use Discourse as a community engine for yo
 
 ## Installation
 
+### Plugin manager from your `wp-admin`
+
+Download the [latest release](https://github.com/discourse/wp-discourse/releases) and upload it in the WordPress admin from Plugins > Add New > Upload Plugin.
+
+### Composer
+
 If you're using Composer to manage WordPress, add WP-Discourse to your project's dependencies. Run:
 
 ```sh

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -47,6 +47,7 @@ class DiscourseAdmin {
     add_settings_field( 'discourse_min_trust_level', 'Min trust level', array( $this, 'min_trust_level_input' ), 'discourse', 'discourse_comments' );
     add_settings_field( 'discourse_bypass_trust_level_score', 'Bypass trust level score', array( $this, 'bypass_trust_level_input' ), 'discourse', 'discourse_comments' );
     add_settings_field( 'discourse_custom_excerpt_length', 'Custom excerpt length', array( $this, 'custom_excerpt_length' ), 'discourse', 'discourse_comments' );
+    add_settings_field( 'discourse_custom_datetime_format', 'Custom Datetime Format', array( $this, 'custom_datetime_format' ), 'discourse', 'discourse_comments' );
 
     add_settings_field( 'discourse_only_show_moderator_liked', 'Only import comments liked by a moderator', array( $this, 'only_show_moderator_liked_checkbox' ), 'discourse', 'discourse_comments' );
     add_settings_field( 'discourse_template_replies', 'HTML Template to use when there are replies', array( $this, 'template_replies_html' ), 'discourse', 'discourse_comments' );
@@ -131,6 +132,10 @@ class DiscourseAdmin {
 
   function custom_excerpt_length() {
     self::text_input( 'custom-excerpt-length', 'Custom excerpt length in words (default: 55)' );
+  }
+
+  function custom_datetime_format(){
+    self::text_input( 'custom-datetime-format', 'Custom comment meta datetime string format (default: "' . get_option('date_format') . '"). See <a href="https://codex.wordpress.org/Formatting_Date_and_Time" target="_blank">this</a> for more info.' );
   }
 
   function bypass_trust_level_input() {

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -41,6 +41,8 @@ class DiscourseAdmin {
     add_settings_field( 'discourse_allowed_post_types', 'Post Types to publish to Discourse', array( $this, 'post_types_select' ), 'discourse', 'discourse_wp_publish' );
 
     add_settings_field( 'discourse_use_discourse_comments', 'Use Discourse Comments', array( $this, 'use_discourse_comments_checkbox' ), 'discourse', 'discourse_comments' );
+    add_settings_field( 'discourse_show_existing_comments', 'Show Existing WP Comments', array( $this, 'show_existing_comments_checkbox' ), 'discourse', 'discourse_comments' );
+    add_settings_field( 'discourse_existing_comments_heading', 'Existing Comments Heading', array( $this, 'existing_comments_heading_input' ), 'discourse', 'discourse_comments' );
     add_settings_field( 'discourse_max_comments', 'Max visible comments', array( $this, 'max_comments_input' ), 'discourse', 'discourse_comments' );
     add_settings_field( 'discourse_min_replies', 'Min number of replies', array( $this, 'min_replies_input' ), 'discourse', 'discourse_comments' );
     add_settings_field( 'discourse_min_score', 'Min score of posts', array( $this, 'min_score_input' ), 'discourse', 'discourse_comments' );
@@ -115,7 +117,15 @@ class DiscourseAdmin {
   }
 
   function use_discourse_comments_checkbox() {
-    self::checkbox_input( 'use-discourse-comments', 'Use Discourse to comment on Discourse published posts (hiding existing comment section)' );
+    self::checkbox_input( 'use-discourse-comments', 'Use Discourse to comment on Discourse published posts' );
+  }
+
+  function show_existing_comments_checkbox() {
+    self::checkbox_input( 'show-existing-comments', 'Display existing WordPress comments beneath Discourse comments' );
+  }
+
+  function existing_comments_heading_input() {
+    self::text_input( 'existing-comments-heading', 'Heading for existing WordPress comments (e.g. "Historical Comment Archive")' );
   }
 
   function min_replies_input() {

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -92,7 +92,7 @@ class Discourse {
     add_action( 'save_post', array( $this, 'save_postdata' ) );
     add_action( 'xmlrpc_publish_post', array( $this, 'xmlrpc_publish_post_to_discourse' ) );
     add_action( 'transition_post_status', array( $this, 'publish_post_to_discourse' ), 10, 3 );
-    add_action( 'parse_request', array( $this, 'sso_parse_request' ) );
+    add_action( 'parse_query', array( $this, 'sso_parse_request' ) );
   }
 
   function discourse_comments_js() {

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -286,23 +286,27 @@ class Discourse {
 
           $permalink = (string) get_post_meta( $postid, 'discourse_permalink', true ) . '/wordpress.json?' . $options;
           $result = wp_remote_get( $permalink );
-          $json = json_decode( $result['body'] );
+          if ( is_wp_error( $result ) ) {
+             error_log( $result->get_error_message() );
+          } else {
+            $json = json_decode( $result['body'] );
 
-          if ( isset( $json->posts_count ) ) {
-            $posts_count = $json->posts_count - 1;
-            if ( $posts_count < 0 ) {
-              $posts_count = 0;
+            if ( isset( $json->posts_count ) ) {
+              $posts_count = $json->posts_count - 1;
+              if ( $posts_count < 0 ) {
+                $posts_count = 0;
+              }
+
+              delete_post_meta( $postid, 'discourse_comments_count' );
+              add_post_meta( $postid, 'discourse_comments_count', $posts_count, true );
+
+              delete_post_meta( $postid, 'discourse_comments_raw' );
+
+              add_post_meta( $postid, 'discourse_comments_raw', esc_sql( $result['body'] ) , true );
+
+              delete_post_meta( $postid, 'discourse_last_sync' );
+              add_post_meta( $postid, 'discourse_last_sync', $time, true );
             }
-
-            delete_post_meta( $postid, 'discourse_comments_count' );
-            add_post_meta( $postid, 'discourse_comments_count', $posts_count, true );
-
-            delete_post_meta( $postid, 'discourse_comments_raw' );
-
-            add_post_meta( $postid, 'discourse_comments_raw', esc_sql( $result['body'] ) , true );
-
-            delete_post_meta( $postid, 'discourse_last_sync' );
-            add_post_meta( $postid, 'discourse_last_sync', $time, true );
           }
         }
         $wpdb->get_results( "SELECT RELEASE_LOCK( 'discourse_lock' )" );
@@ -480,16 +484,20 @@ class Discourse {
         'body' => http_build_query( $data ),
       );
       $result = wp_remote_post( $url, $post_options);
-      $json = json_decode( $result['body'] );
+      if ( is_wp_error( $result ) ) {
+        error_log( $result->get_error_message() );
+      } else {
+        $json = json_decode( $result['body'] );
 
-      // todo may have $json->errors with list of errors
+        // todo may have $json->errors with list of errors
 
-      if( property_exists( $json, 'id' ) ) {
-        $discourse_id = (int) $json->id;
-      }
+        if( property_exists( $json, 'id' ) ) {
+          $discourse_id = (int) $json->id;
+        }
 
-      if( isset( $discourse_id ) && $discourse_id > 0 ) {
-        add_post_meta( $postid, 'discourse_post_id', $discourse_id, true );
+        if( isset( $discourse_id ) && $discourse_id > 0 ) {
+          add_post_meta( $postid, 'discourse_post_id', $discourse_id, true );
+        }
       }
     } else {
       // for now the updates are just causing grief, leave'em out

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -111,7 +111,7 @@ class Discourse {
           $discourse_url = $discourse_options['url'];
         ?>
         var discourse_url = '<?php echo $discourse_url; ?>';
-        jQuery(this).attr("href", discourse_url + jQuery(this).attr("href"));
+        jQuery(this).attr('href', discourse_url + jQuery(this).attr('href'));
       });
     });
     </script>

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -285,10 +285,8 @@ class Discourse {
           $options = $options . '&api_key=' . $discourse_options['api-key'] . '&api_username=' . $discourse_options['publish-username'];
 
           $permalink = (string) get_post_meta( $postid, 'discourse_permalink', true ) . '/wordpress.json?' . $options;
-          $soptions = array( 'http' => array( 'ignore_errors' => true, 'method'  => 'GET' ) );
-          $context = stream_context_create( $soptions );
-          $result = file_get_contents( $permalink, false, $context );
-          $json = json_decode( $result );
+          $result = wp_remote_get( $permalink );
+          $json = json_decode( $result['body'] );
 
           if ( isset( $json->posts_count ) ) {
             $posts_count = $json->posts_count - 1;
@@ -301,7 +299,7 @@ class Discourse {
 
             delete_post_meta( $postid, 'discourse_comments_raw' );
 
-            add_post_meta( $postid, 'discourse_comments_raw', esc_sql( $result ) , true );
+            add_post_meta( $postid, 'discourse_comments_raw', esc_sql( $result['body'] ) , true );
 
             delete_post_meta( $postid, 'discourse_last_sync' );
             add_post_meta( $postid, 'discourse_last_sync', $time, true );
@@ -476,17 +474,13 @@ class Discourse {
       $url =  $options['url'] .'/posts';
 
       // use key 'http' even if you send the request to https://...
-      $soptions = array(
-        'http' => array(
-          'ignore_errors' => true,
-          'method'  => 'POST',
-          'content' => http_build_query( $data ),
-          'header' => "Content-Type: application/x-www-form-urlencoded\r\n"
-        )
+      $post_options = array(
+        'timeout' => 30,
+        'method' => 'POST',
+        'body' => http_build_query( $data ),
       );
-      $context = stream_context_create( $soptions );
-      $result = file_get_contents( $url, false, $context );
-      $json = json_decode( $result );
+      $result = wp_remote_post( $url, $post_options);
+      $json = json_decode( $result['body'] );
 
       // todo may have $json->errors with list of errors
 
@@ -501,10 +495,9 @@ class Discourse {
       // for now the updates are just causing grief, leave'em out
       return;
       $url = $options['url'] .'/posts/' . $discourse_id ;
-      $soptions = array( 'http' => array( 'ignore_errors' => true, 'method'  => 'PUT','content' => http_build_query( $data) ));
-      $context = stream_context_create( $soptions);
-      $result = file_get_contents( $url, false, $context );
-      $json = json_decode( $result );
+      $post_options = array( 'method' => 'PUT', 'body' => http_build_query( $data ) );
+      $result = wp_remote_post( $url, $post_options );
+      $json = json_decode( $result['body'] );
 
       if(isset( $json->post ) ) {
         $json = $json->post;

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -309,9 +309,19 @@ class Discourse {
 
     if( self::use_discourse_comments( $post->ID ) ) {
       self::sync_comments( $post->ID );
-      return WPDISCOURSE_PATH . '/templates/comments.php';
+      $options = self::get_plugin_options();
+      $num_WP_comments = get_comments_number();
+      if ( ! $options['show-existing-comments'] || $num_WP_comments == 0 ) {
+        // only show the Discourse comments
+        return WPDISCOURSE_PATH . '/templates/comments.php';
+      } else {
+        // show the Discourse comments then show the existing WP comments (in $old)
+        include WPDISCOURSE_PATH . '/templates/comments.php';
+        echo '<div class="discourse-existing-comments-heading">' . $options['existing-comments-heading'] . '</div>';
+        return $old;
+      }
     }
-
+    // show the existing WP comments
     return $old;
   }
 

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -146,7 +146,7 @@ class Discourse {
         $redirect = str_replace( '%0A', '%0B', $redirect );
 
         // Build login URL
-        $login = wp_login_url( $redirect );
+        $login = wp_login_url( esc_url_raw( $redirect ) );
 
         // Redirect to login
         wp_redirect( $login );

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -105,6 +105,14 @@ class Discourse {
             url = 'https://www.youtube.com/watch?v=' + id;
         jQuery(this).replaceWith('<a href="' + url + '">' + url + '</a>');
       });
+      jQuery('a.mention').each(function() {
+        <?php
+          $discourse_options = self::get_plugin_options();
+          $discourse_url = $discourse_options['url'];
+        ?>
+        var discourse_url = '<?php echo $discourse_url; ?>';
+        jQuery(this).attr("href", discourse_url + jQuery(this).attr("href"));
+      });
     });
     </script>
   <?php

--- a/templates/comments.php
+++ b/templates/comments.php
@@ -18,6 +18,9 @@ $defaults = array(
   'participants' => array()
 );
 
+// use custom datetime format string if provided, else global date format
+$datetime_format = $options['custom-datetime-format'] == '' ? get_option('date_format') : $options['custom-datetime-format'];
+
 // Add some protection in the event our metadata doesn't look how we expect it to
 $discourse_info = (object)wp_parse_args((array)$discourse_info, $defaults);
 
@@ -47,7 +50,7 @@ if(count($discourse_info->posts) > 0) {
     $comment_html = str_replace('{username}', $post->username, $comment_html);
     $comment_html = str_replace('{fullname}', $post->name, $comment_html);
     $comment_html = str_replace('{comment_body}', Discourse::convert_relative_img_src_to_absolute($discourse_url, $post->cooked), $comment_html);
-    $comment_html = str_replace('{comment_created_at}', mysql2date(get_option('date_format'), $post->created_at), $comment_html);
+    $comment_html = str_replace('{comment_created_at}', mysql2date($datetime_format, $post->created_at), $comment_html);
     $comments_html .= $comment_html;
   }
   foreach($discourse_info->participants as &$participant) {

--- a/templates/comments.php
+++ b/templates/comments.php
@@ -18,6 +18,10 @@ $defaults = array(
   'participants' => array()
 );
 
+// add <time> tag to WP allowed html tags
+global $allowedposttags;
+$allowedposttags['time'] = array('datetime'=>array());
+
 // use custom datetime format string if provided, else global date format
 $datetime_format = $options['custom-datetime-format'] == '' ? get_option('date_format') : $options['custom-datetime-format'];
 


### PR DESCRIPTION
Allows user to provide a custom datetime formatting string for the comment meta datatime (basically allows inclusion of the time since the original version of this was only including the date).

Looks like this in the admin:
![2015-04-21 at 12 09 pm](https://cloud.githubusercontent.com/assets/327716/7257997/4e7c6d16-e81f-11e4-9d26-cd59d2e37739.png)

And allows doing stuff like this on the front end:
![2015-04-21 at 12 10 pm](https://cloud.githubusercontent.com/assets/327716/7258021/6f8cef08-e81f-11e4-8c8d-2d9e9e05f0b6.png)
