### PR TITLE
Allow showing existing WP comments under Discourse

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -41,6 +41,8 @@ class DiscourseAdmin {
     add_settings_field( 'discourse_allowed_post_types', 'Post Types to publish to Discourse', array( $this, 'post_types_select' ), 'discourse', 'discourse_wp_publish' );
 
     add_settings_field( 'discourse_use_discourse_comments', 'Use Discourse Comments', array( $this, 'use_discourse_comments_checkbox' ), 'discourse', 'discourse_comments' );
+    add_settings_field( 'discourse_show_existing_comments', 'Show Existing WP Comments', array( $this, 'show_existing_comments_checkbox' ), 'discourse', 'discourse_comments' );
+    add_settings_field( 'discourse_existing_comments_heading', 'Existing Comments Heading', array( $this, 'existing_comments_heading_input' ), 'discourse', 'discourse_comments' );
     add_settings_field( 'discourse_max_comments', 'Max visible comments', array( $this, 'max_comments_input' ), 'discourse', 'discourse_comments' );
     add_settings_field( 'discourse_min_replies', 'Min number of replies', array( $this, 'min_replies_input' ), 'discourse', 'discourse_comments' );
     add_settings_field( 'discourse_min_score', 'Min score of posts', array( $this, 'min_score_input' ), 'discourse', 'discourse_comments' );
@@ -114,7 +116,15 @@ class DiscourseAdmin {
   }
 
   function use_discourse_comments_checkbox() {
-    self::checkbox_input( 'use-discourse-comments', 'Use Discourse to comment on Discourse published posts (hiding existing comment section)' );
+    self::checkbox_input( 'use-discourse-comments', 'Use Discourse to comment on Discourse published posts' );
+  }
+
+  function show_existing_comments_checkbox() {
+    self::checkbox_input( 'show-existing-comments', 'Display existing WordPress comments beneath Discourse comments' );
+  }
+
+  function existing_comments_heading_input() {
+    self::text_input( 'existing-comments-heading', 'Heading for existing WordPress comments (e.g. "Historical Comment Archive")' );
   }
 
   function min_replies_input() {

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -309,9 +309,19 @@ class Discourse {
 
     if( self::use_discourse_comments( $post->ID ) ) {
       self::sync_comments( $post->ID );
-      return WPDISCOURSE_PATH . '/templates/comments.php';
+      $options = self::get_plugin_options();
+      $num_WP_comments = get_comments_number();
+      if ( ! $options['show-existing-comments'] || $num_WP_comments == 0 ) {
+        // only show the Discourse comments
+        return WPDISCOURSE_PATH . '/templates/comments.php';
+      } else {
+        // show the Discourse comments then show the existing WP comments (in $old)
+        include WPDISCOURSE_PATH . '/templates/comments.php';
+        echo '<div class="discourse-existing-comments-heading">' . $options['existing-comments-heading'] . '</div>';
+        return $old;
+      }
     }
-
+    // show the existing WP comments
     return $old;
   }
 


### PR DESCRIPTION
This patch is my answer to what to do about enabling Discourse comments for existing posts/pages that have a lot of valuable pre-existing WP comments on them. The prior behavior of the plugin makes you choose to either show Discourse comments and hide the old WP comments OR show the WP comments and not show the Discourse comments. This patch lets you choose to show the existing WP comments as a "historical archive" beneath the new Discourse comments.

In the admin:
![2015-04-21 at 11 44 am](https://cloud.githubusercontent.com/assets/327716/7257508/d49f75b8-e81b-11e4-88f6-c6c32a4f40f3.png)

I wrapped the "Existing Comments Heading" in a `<div>` with a class of `discourse-existing-comments-heading` so it is easy to style it with css to fit your theme.

On the front end:
![2015-04-21 at 11 45 am](https://cloud.githubusercontent.com/assets/327716/7257544/2cbb2594-e81c-11e4-81ea-341dbdcf6008.png)