### PR TITLE
Choose discourse category per post

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -33,6 +33,7 @@ class DiscourseAdmin {
     add_settings_field( 'discourse_sso_secret', 'SSO Secret Key', array( $this, 'sso_secret_input' ), 'discourse', 'discourse_wp_sso' );
 
     add_settings_field( 'discourse_publish_category', 'Published category', array( $this, 'publish_category_input' ), 'discourse', 'discourse_wp_publish' );
+    add_settings_field( 'discourse_publish_category_update', 'Force category update', array( $this, 'publish_category_input_update' ), 'discourse', 'discourse_wp_publish' );
     add_settings_field( 'discourse_publish_format', 'Publish format', array( $this, 'publish_format_textarea' ), 'discourse', 'discourse_wp_publish' );
     add_settings_field( 'discourse_full_post_content', 'Use full post content', array( $this, 'full_post_checkbox' ), 'discourse', 'discourse_wp_publish' );
 
@@ -90,7 +91,11 @@ class DiscourseAdmin {
   }
 
   function publish_category_input() {
-    self::category_select( 'publish-category', 'Category post will be published in Discourse (optional)' );
+    self::category_select( 'publish-category', 'Default category used to published in Discourse (optional)' );
+  }
+
+  function publish_category_input_update() {
+    self::checkbox_input( 'publish-category-update', 'Update the discourse publish category list, normaly set for an hour (normaly set to refresh every hour)' );
   }
 
   function publish_format_textarea() {
@@ -201,8 +206,7 @@ class DiscourseAdmin {
     echo '</select>';
   }
 
-
-  function category_select( $option, $description ) {
+  function get_discourse_categories($force_update='0'){
     $options = get_option( 'discourse' );
     $url = $options['url'] . '/categories.json';
 
@@ -210,22 +214,24 @@ class DiscourseAdmin {
       "api_key" => $options['api-key'] ,
       "api_username" => $options['publish-username']
     ), $url );
+    $force_update = isset($options['publish-category-update']) ? $options['publish-category-update'] : '0';
 
     $remote = get_transient( "discourse_settings_categories_cache" );
-
-    if( empty( $remote ) ){
+    $cache = $remote;
+    if( empty($remote) or $force_update == '1' ){
       $remote = wp_remote_get( $url );
 
-      if( is_wp_error( $remote ) ) {
-        self::text_input( $option, $description );
-        return;
+      if( is_wp_error( $remote ) and ! empty( $cache ) ) {
+        $remote = $cache;
+      }
+      elseif(is_wp_error( $remote )) {
+        return $remote;
       }
 
       $remote = wp_remote_retrieve_body( $remote );
 
       if( is_wp_error( $remote ) ) {
-        self::text_input( $option, $description );
-        return;
+        return $remote;
       }
 
       $remote = json_decode( $remote, true );
@@ -234,100 +240,134 @@ class DiscourseAdmin {
     }
 
     $categories = $remote['category_list']['categories'];
-    $selected = isset( $options['publish-category'] ) ? $options['publish-category'] : '';
-
-    echo "<select id='discourse[{$option}]' name='discourse[{$option}]'>";
-    echo '<option></option>';
-
-    foreach( $categories as $category ){
-      printf( '<option value="%s"%s>%s</option>',
-        $category['id'],
-        selected( $selected, $category['id'], false ),
-        $category['name']
-      );
-    }
-
-    echo '</select>';
+    return $categories;
   }
 
-  function text_input( $option, $description ) {
-    $options = $this->options;
+  function category_select( $option, $description ) {
+    $options = get_option( 'discourse' );
 
-    if ( array_key_exists( $option, $options ) ) {
-      $value = $options[$option];
+    $force_update = isset($options['publish-category-update']) ? $options['publish-category-update'] : '0';
+    $categories = self::get_discourse_categories($force_update);
+
+    if( is_wp_error( $categories ) ) {
+     self::text_input( $option, $description );
+     return;
+   }
+
+   $selected = isset( $options['publish-category'] ) ? $options['publish-category'] : '';
+   $name = "discourse[{$option}]";
+   self::option_input($name, $categories, $selected);
+ }
+
+ function option_input($name, $group, $selected){
+   echo "<select id='$name' name='$name'>";
+   echo '<option></option>';
+   foreach( $group as $item ){
+    printf( '<option value="%s"%s>%s</option>',
+     $item['id'],
+     selected( $selected, $item['id'], false ),
+     $item['name']
+     );
+
+
+  }
+
+  echo '</select>';
+}
+
+function text_input( $option, $description ) {
+  $options = $this->options;
+
+  if ( array_key_exists( $option, $options ) ) {
+    $value = $options[$option];
+  } else {
+    $value = '';
+  }
+
+  ?>
+  <input id='discourse_<?php echo $option?>' name='discourse[<?php echo $option?>]' type='text' value='<?php echo esc_attr( $value ); ?>' class="regular-text ltr" />
+  <p class="description"><?php echo $description ?></p>
+  <?php
+
+}
+
+function text_area( $option, $description) {
+  $options = $this->options;
+
+  if ( array_key_exists( $option, $options ) ) {
+    $value = $options[$option];
+  } else {
+    $value = '';
+  }
+
+  ?>
+  <textarea cols=100 rows=6 id='discourse_<?php echo $option?>' name='discourse[<?php echo $option?>]'><?php echo esc_textarea( $value ); ?></textarea>
+  <p class="description"><?php echo $description ?></p>
+  <?php
+
+}
+
+function discourse_validate_options( $inputs ) {
+  foreach ( $inputs as $key => $input ) {
+    $inputs[ $key ] = is_string( $input ) ? trim( $input ) : $input;
+  }
+
+  $inputs['url'] = untrailingslashit( $inputs['url'] );
+  return $inputs;
+}
+
+function discourse_admin_menu(){
+  add_options_page( 'Discourse', 'Discourse', 'manage_options', 'discourse', array ( $this, 'discourse_options_page' ) );
+}
+
+function discourse_options_page() {
+  if ( !current_user_can( 'manage_options' ) )  {
+    wp_die( __( 'You do not have sufficient permissions to access this page.' ) );
+  }
+  ?>
+  <div class="wrap">
+    <h2>Discourse Options</h2>
+    <form action="options.php" method="POST">
+      <?php settings_fields( 'discourse' ); ?>
+      <?php do_settings_sections( 'discourse' ); ?>
+      <?php submit_button(); ?>
+    </form>
+  </div>
+  <?php
+}
+
+function publish_to_discourse() {
+  global $post;
+
+  $options = Discourse::get_plugin_options();
+
+  if( in_array( $post->post_type, $options['allowed_post_types'] ) ) {
+    if( $post->post_status == 'auto-draft' ) {
+      $value = $options['auto-publish'];
     } else {
-      $value = '';
+      $value = get_post_meta( $post->ID, 'publish_to_discourse', true );
     }
 
-    ?>
-    <input id='discourse_<?php echo $option?>' name='discourse[<?php echo $option?>]' type='text' value='<?php echo esc_attr( $value ); ?>' class="regular-text ltr" />
-    <p class="description"><?php echo $description ?></p>
-    <?php
-
-  }
-
-  function text_area( $option, $description) {
-    $options = $this->options;
-
-    if ( array_key_exists( $option, $options ) ) {
-      $value = $options[$option];
-    } else {
-      $value = '';
+    $categories = self::get_discourse_categories('0');
+    if(is_wp_error($categories)){
+      echo '<span>Unable to retrieve discourse categories at this time. Please save draft to refresh the page.</span>';
     }
-
-    ?>
-    <textarea cols=100 rows=6 id='discourse_<?php echo $option?>' name='discourse[<?php echo $option?>]'><?php echo esc_textarea( $value ); ?></textarea>
-    <p class="description"><?php echo $description ?></p>
-    <?php
-
-  }
-
-  function discourse_validate_options( $inputs ) {
-    foreach ( $inputs as $key => $input ) {
-      $inputs[ $key ] = is_string( $input ) ? trim( $input ) : $input;
-    }
-
-    $inputs['url'] = untrailingslashit( $inputs['url'] );
-    return $inputs;
-  }
-
-  function discourse_admin_menu(){
-    add_options_page( 'Discourse', 'Discourse', 'manage_options', 'discourse', array ( $this, 'discourse_options_page' ) );
-  }
-
-  function discourse_options_page() {
-    if ( !current_user_can( 'manage_options' ) )  {
-      wp_die( __( 'You do not have sufficient permissions to access this page.' ) );
-    }
-    ?>
-    <div class="wrap">
-        <h2>Discourse Options</h2>
-        <form action="options.php" method="POST">
-            <?php settings_fields( 'discourse' ); ?>
-            <?php do_settings_sections( 'discourse' ); ?>
-            <?php submit_button(); ?>
-        </form>
-    </div>
-    <?php
-  }
-
-  function publish_to_discourse() {
-    global $post;
-
-    $options = Discourse::get_plugin_options();
-
-    if( in_array( $post->post_type, $options['allowed_post_types'] ) ) {
-      if( $post->post_status == 'auto-draft' ) {
-        $value = $options['auto-publish'];
-      } else {
-        $value = get_post_meta( $post->ID, 'publish_to_discourse', true );
-      }
-
+    else {
       echo '<div class="misc-pub-section misc-pub-section-last">
-           <span>'
-           . '<input type="hidden" name="showed_publish_option" value="1">'
-           . '<label><input type="checkbox"' . (( $value == "1") ? ' checked="checked" ' : null) . 'value="1" name="publish_to_discourse" /> Publish to Discourse</label>'
-      .'</span></div>';
-    }
-  }
+      <span>'
+       . '<input type="hidden" name="showed_publish_option" value="1">';
+
+
+       print "<label>";
+       $publish_post_category = get_post_meta( $post->ID, 'publish_post_category', true);
+       $default_category = isset( $options['publish-category'] ) ? $options['publish-category'] : '';
+       $selected = (! empty( $publish_post_category ) ) ? $publish_post_category : $default_category;
+       self::option_input('publish_post_category', $categories, $selected);
+       echo ' Discourse Category</label>';
+
+       echo '<label><input type="checkbox"' . (( $value == "1") ? ' checked="checked" ' : null) . 'value="1" name="publish_to_discourse" /> Publish to Discourse</label>'
+       .'</span></div>';
+     }
+   }
+ }
 }

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -317,9 +317,17 @@ class Discourse {
 
   function publish_post_to_discourse( $new_status, $old_status, $post ) {
     $publish_to_discourse = get_post_meta( $post->ID, 'publish_to_discourse', true );
+
+    $publish_post_category = get_post_meta( $post->ID, 'publish_post_category', true );
     if ( ( self::publish_active() || ! empty( $publish_to_discourse ) ) && $new_status == 'publish' && self::is_valid_sync_post_type( $post->ID ) ) {
       // This seems a little redundant after `save_postdata` but when using the Press This
       // widget it updates the field as it should.
+
+      // This could be improved, need to be validated
+      if( isset( $_POST['publish_post_category'] ) ){
+        #delete_post_meta( $post->ID, 'publish_post_category');
+        add_post_meta( $post->ID, 'publish_post_category', $_POST['publish_post_category'], true );
+      }
 
       add_post_meta( $post->ID, 'publish_to_discourse', '1', true );
 
@@ -382,6 +390,12 @@ class Discourse {
       delete_post_meta( $_POST['ID'], 'publish_to_discourse' );
     }
 
+    if ( isset( $_POST['publish_post_category'] ) ){
+      delete_post_meta($_POST['ID'], 'publish_post_category');
+      add_post_meta( $_POST['ID'], 'publish_post_category',  $_POST['publish_post_category'], true );
+    }
+
+
     add_post_meta( $_POST['ID'], 'publish_to_discourse', self::publish_active() ? '1' : '0', true );
 
     return $postid;
@@ -431,7 +445,12 @@ class Discourse {
       $username = $options['publish-username'];
     }
 
-    $category = $options['publish-category'];
+    // Get publish category of a post
+    $publish_post_category = get_post_meta( $post->ID, 'publish_post_category', true );
+    $publish_post_category =  $post->publish_post_category;
+    $default_category = isset( $options['publish-category'] ) ? $options['publish-category'] : '';
+    $category = isset( $publish_post_category ) ? $publish_post_category : $default_category;
+
     if ( $category === '' ) {
       $categories = get_the_category();
       foreach ( $categories as $category ) {
@@ -456,7 +475,6 @@ class Discourse {
 
     if( ! $discourse_id > 0 ) {
       $url =  $options['url'] .'/posts';
-
       // use key 'http' even if you send the request to https://...
       $soptions = array(
         'http' => array(


### PR DESCRIPTION
With wp-discourse you can only select one discourse category in which your posts get published. In our context we have multiple categories we want to use and to be able to select that per post; blog posts to Blog, and product posts to Products.

I modified wp-discourse to add the category drop down on the publish meta box, and used it as the published discourse category. 

I also added a field to give the option to force update the category list instead of using the cache. This is something I needed because an hour was to long (since I was setting up a new discourse for testing, and i was adding new categories). It could be removed or replace with something better.