### PR TITLE
add custom datetime format string to admin settings

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -49,6 +49,7 @@ class DiscourseAdmin {
     add_settings_field( 'discourse_min_trust_level', 'Min trust level', array( $this, 'min_trust_level_input' ), 'discourse', 'discourse_comments' );
     add_settings_field( 'discourse_bypass_trust_level_score', 'Bypass trust level score', array( $this, 'bypass_trust_level_input' ), 'discourse', 'discourse_comments' );
     add_settings_field( 'discourse_custom_excerpt_length', 'Custom excerpt length', array( $this, 'custom_excerpt_length' ), 'discourse', 'discourse_comments' );
+    add_settings_field( 'discourse_custom_datetime_format', 'Custom Datetime Format', array( $this, 'custom_datetime_format' ), 'discourse', 'discourse_comments' );
 
     add_settings_field( 'discourse_only_show_moderator_liked', 'Only import comments liked by a moderator', array( $this, 'only_show_moderator_liked_checkbox' ), 'discourse', 'discourse_comments' );
     add_settings_field( 'discourse_template_replies', 'HTML Template to use when there are replies', array( $this, 'template_replies_html' ), 'discourse', 'discourse_comments' );
@@ -141,6 +142,10 @@ class DiscourseAdmin {
 
   function custom_excerpt_length() {
     self::text_input( 'custom-excerpt-length', 'Custom excerpt length in words (default: 55)' );
+  }
+
+  function custom_datetime_format(){
+    self::text_input( 'custom-datetime-format', 'Custom comment meta datetime string format (default: "' . get_option('date_format') . '"). See <a href="https://codex.wordpress.org/Formatting_Date_and_Time" target="_blank">this</a> for more info.' );
   }
 
   function bypass_trust_level_input() {

--- a/templates/comments.php
+++ b/templates/comments.php
@@ -22,6 +22,9 @@ $defaults = array(
 global $allowedposttags;
 $allowedposttags['time'] = array('datetime'=>array());
 
+// use custom datetime format string if provided, else global date format
+$datetime_format = $options['custom-datetime-format'] == '' ? get_option('date_format') : $options['custom-datetime-format'];
+
 // Add some protection in the event our metadata doesn't look how we expect it to
 $discourse_info = (object)wp_parse_args((array)$discourse_info, $defaults);
 
@@ -51,7 +54,7 @@ if(count($discourse_info->posts) > 0) {
     $comment_html = str_replace('{username}', $post->username, $comment_html);
     $comment_html = str_replace('{fullname}', $post->name, $comment_html);
     $comment_html = str_replace('{comment_body}', Discourse::convert_relative_img_src_to_absolute($discourse_url, $post->cooked), $comment_html);
-    $comment_html = str_replace('{comment_created_at}', mysql2date(get_option('date_format'), $post->created_at), $comment_html);
+    $comment_html = str_replace('{comment_created_at}', mysql2date($datetime_format, $post->created_at), $comment_html);
     $comments_html .= $comment_html;
   }
   foreach($discourse_info->participants as &$participant) {


### PR DESCRIPTION
Allows user to provide a custom datetime formatting string for the comment meta datatime (basically allows inclusion of the time since the original version of this was only including the date).