### PR TITLE
fix timezone for custom timestamp

### DIFF
--- a/templates/comments.php
+++ b/templates/comments.php
@@ -54,7 +54,7 @@ if(count($discourse_info->posts) > 0) {
     $comment_html = str_replace('{username}', $post->username, $comment_html);
     $comment_html = str_replace('{fullname}', $post->name, $comment_html);
     $comment_html = str_replace('{comment_body}', Discourse::convert_relative_img_src_to_absolute($discourse_url, $post->cooked), $comment_html);
-    $comment_html = str_replace('{comment_created_at}', mysql2date($datetime_format, $post->created_at), $comment_html);
+    $comment_html = str_replace('{comment_created_at}', mysql2date($datetime_format, get_date_from_gmt($post->created_at)), $comment_html);
     $comments_html .= $comment_html;
   }
   foreach($discourse_info->participants as &$participant) {


### PR DESCRIPTION
Discourse (properly) sends the timestamp for posts/comments back to wordpress as UTC. The plugin needs to convert to the blog's local timezone before displaying it.