### PR TITLE
Allow redirect to Discourse without login

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -42,6 +42,7 @@ class DiscourseAdmin {
 
     add_settings_field( 'discourse_use_discourse_comments', 'Use Discourse Comments', array( $this, 'use_discourse_comments_checkbox' ), 'discourse', 'discourse_comments' );
     add_settings_field( 'discourse_show_existing_comments', 'Show Existing WP Comments', array( $this, 'show_existing_comments_checkbox' ), 'discourse', 'discourse_comments' );
+    add_settings_field( 'discourse_redirect_without_login', 'Redirect Without Login', array( $this, 'redirect_without_login_checkbox' ), 'discourse', 'discourse_comments' );
     add_settings_field( 'discourse_existing_comments_heading', 'Existing Comments Heading', array( $this, 'existing_comments_heading_input' ), 'discourse', 'discourse_comments' );
     add_settings_field( 'discourse_max_comments', 'Max visible comments', array( $this, 'max_comments_input' ), 'discourse', 'discourse_comments' );
     add_settings_field( 'discourse_min_replies', 'Min number of replies', array( $this, 'min_replies_input' ), 'discourse', 'discourse_comments' );
@@ -122,6 +123,10 @@ class DiscourseAdmin {
 
   function show_existing_comments_checkbox() {
     self::checkbox_input( 'show-existing-comments', 'Display existing WordPress comments beneath Discourse comments' );
+  }
+
+  function redirect_without_login_checkbox() {
+    self::checkbox_input( 'redirect-without-login', 'Do not force login for link to Discourse comments thread<br />(No effect if not using SSO)' );
   }
 
   function existing_comments_heading_input() {

--- a/templates/comments.php
+++ b/templates/comments.php
@@ -3,7 +3,7 @@ $custom = get_post_custom();
 $options = get_option('discourse');
 $is_enable_sso = (isset( $options['enable-sso'] ) && intval( $options['enable-sso'] ) == 1);
 $permalink = (string)$custom['discourse_permalink'][0];
-if($is_enable_sso) {
+if($is_enable_sso && ! $options['redirect-without-login'] ) {
   $permalink = esc_url($options['url']) . '/session/sso?return_path=' . $permalink;
 }
 $discourse_url_name = preg_replace( "(https?://)", "", $options['url'] );


### PR DESCRIPTION
if using SSO, the link that wp-discourse generates that sends the user to the Discourse thread to comment on the WP post ("continue the discussion in our forum"), forces the user to login before they are redirected to the Discourse thread.

i decided that i wanted to have the link redirect straight to the thread without an intervening login page. if the user wants to post when they get there, they can click the "login to reply" button in Discourse.

this patch adds a setting in the admin that allows this behavior (but leaves the default as-is).