### PR TITLE
Default publishing username as system

### DIFF
--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -20,7 +20,7 @@ class Discourse {
     'api-key' => '',
     'enable-sso' => 0,
     'sso-secret' => '',
-    'publish-username' => '',
+    'publish-username' => 'system',
     'publish-category' => '',
     'auto-publish' => 0,
     'allowed_post_types' => array( 'post', 'page' ),


### PR DESCRIPTION
I think people sometimes don't realize that a fallback username should be entered in this field. "system" is a pretty safe default.