### PR TITLE
Better method for including comments script and other small tweaks

### DIFF
--- a/js/comments.js
+++ b/js/comments.js
@@ -1,0 +1,10 @@
+jQuery(document).ready(function() {
+	jQuery('.lazyYT').each(function() {
+		var id = jQuery(this).data('youtube-id'),
+			url = 'https://www.youtube.com/watch?v=' + id;
+		jQuery(this).replaceWith('<a href="' + url + '">' + url + '</a>');
+	});
+	jQuery('a.mention').each(function() {
+		jQuery(this).attr('href', discourse_url + jQuery(this).attr('href'));
+	});
+});

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -73,11 +73,16 @@ class DiscourseAdmin {
   }
 
   function url_input() {
-    self::text_input( 'url', '' );
+    self::text_input( 'url', 'e.g. http://discourse.example.com' );
   }
 
   function api_key_input() {
-    self::text_input( 'api-key', '' );
+    $discourse_options = Discourse::get_plugin_options();
+    if ( isset( $discourse_options['url'] ) && ! empty( $discourse_options['url'] ) ) {
+      self::text_input( 'api-key', 'Found at <a href="' . esc_url( $discourse_options['url'] ) . '/admin/api" target="_blank">' . esc_url( $discourse_options['url'] ) . '/admin/api</a>' );
+    } else {
+      self::text_input( 'api-key', 'Found at http://discourse.example.com/admin/api' );
+    }
   }
 
   function enable_sso_checkbox() {

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -96,7 +96,7 @@ class Discourse {
 
   function discourse_comments_js() {
     // Allowed post type
-    if ( is_singular( $this->get_allowed_post_types() ) ) {
+    if ( is_singular( self::get_allowed_post_types() ) ) {
       // Publish to Discourse enabled
       if ( self::use_discourse_comments( get_the_ID() ) ) {
         // Enqueue script

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -20,10 +20,10 @@ class Discourse {
     'api-key' => '',
     'enable-sso' => 0,
     'sso-secret' => '',
-    'publish-username' => '',
+    'publish-username' => 'system',
     'publish-category' => '',
     'auto-publish' => 0,
-    'allowed_post_types' => array( 'post', 'page' ),
+    'allowed_post_types' => array( 'post' ),
     'auto-track' => 1,
     'max-comments' => 5,
     'use-discourse-comments' => 0,
@@ -31,7 +31,7 @@ class Discourse {
     'min-score' => 30,
     'min-replies' => 5,
     'min-trust-level' => 1,
-    'custom-excerpt-length' => '55',
+    'custom-excerpt-length' => 55,
     'bypass-trust-level-score' => 50,
     'debug-mode' => 0,
     'full-post-content' => 0,
@@ -70,7 +70,6 @@ class Discourse {
 
   public function __construct() {
     add_action( 'init', array( $this, 'init' ) );
-    add_action( 'wp_footer', array( $this, 'discourse_comments_js' ), 100 );
   }
 
   static function install() {
@@ -87,7 +86,7 @@ class Discourse {
     add_filter( 'comments_template', array( $this, 'comments_template' ) );
     add_filter( 'query_vars', array( $this, 'sso_add_query_vars' ) );
 
-    wp_enqueue_script( 'jquery' );
+    add_action( 'wp_enqueue_scripts', array( $this, 'discourse_comments_js' ) );
 
     add_action( 'save_post', array( $this, 'save_postdata' ) );
     add_action( 'xmlrpc_publish_post', array( $this, 'xmlrpc_publish_post_to_discourse' ) );
@@ -96,26 +95,25 @@ class Discourse {
   }
 
   function discourse_comments_js() {
-    if ( wp_script_is( 'jquery', 'done' ) ) {
-  ?>
-    <script>
-    jQuery(document).ready(function() {
-      jQuery('.lazyYT').each(function() {
-        var id = jQuery(this).data('youtube-id'),
-            url = 'https://www.youtube.com/watch?v=' + id;
-        jQuery(this).replaceWith('<a href="' + url + '">' + url + '</a>');
-      });
-      jQuery('a.mention').each(function() {
-        <?php
-          $discourse_options = self::get_plugin_options();
-          $discourse_url = $discourse_options['url'];
-        ?>
-        var discourse_url = '<?php echo $discourse_url; ?>';
-        jQuery(this).attr('href', discourse_url + jQuery(this).attr('href'));
-      });
-    });
-    </script>
-  <?php
+    // Allowed post type
+    if ( is_singular( $this->get_allowed_post_types() ) ) {
+      // Publish to Discourse enabled
+      if ( self::use_discourse_comments( get_the_ID() ) ) {
+        // Enqueue script
+        wp_enqueue_script(
+          'discourse-comments-js',
+          WPDISCOURSE_URL . '/js/comments.js',
+          array( 'jquery' ),
+          self::$version,
+          true
+        );
+        // Localize script
+        $discourse_options = self::get_plugin_options();
+        $data = array(
+          'url' => $discourse_options['url'],
+        );
+        wp_localize_script( 'discourse-comments-js', 'discourse', $data );
+      }
     }
   }
 

--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -26,6 +26,7 @@ GitHub Plugin URI: https://github.com/discourse/wp-discourse
 */
 
 define( 'WPDISCOURSE_PATH', plugin_dir_path( __FILE__ ) );
+define( 'WPDISCOURSE_URL', plugins_url( '', __FILE__ ) );
 
 require_once( __DIR__ . '/lib/discourse.php' );
 require_once( __DIR__ . '/lib/admin.php' );


### PR DESCRIPTION
`wp_enqueue_scripts` should absolutely be used instead of including a script directly through `wp_footer`.

The default publishing username should be `system` instead of nothing. I think sometimes users don't realize they should fill out that field. When it's blank and the user hasn't filled out a Discourse username in their profile, then publishing fails.

Default posts types should just be post. People typically don't allow comments on pages.