### PR TITLE
call add_query_arg() with NULL, NULL as arguments

### DIFF
--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -151,7 +151,7 @@ class Discourse {
       if ( ! is_user_logged_in() ) {
 
         // Preserve sso and sig parameters
-        $redirect = add_query_arg();
+        $redirect = add_query_arg( NULL, NULL );
 
         // Change %0A to %0B so it's not stripped out in wp_sanitize_redirect
         $redirect = str_replace( '%0A', '%0B', $redirect );


### PR DESCRIPTION
Calling `add_query_arg` without arguments produces the following notice when `'WP_DEBUG'` is set to `true`:

```
Notice: Undefined offset: 0 in /Users/scossar/testeleven/wp-mamp/wordpress/wp-includes/functions.php on line 772

Notice: Undefined offset: 0 in /Users/scossar/testeleven/wp-mamp/wordpress/wp-includes/functions.php on line 812

Notice: Undefined offset: 0 in /Users/scossar/testeleven/wp-mamp/wordpress/wp-includes/functions.php on line 817

Notice: Undefined offset: 1 in /Users/scossar/testeleven/wp-mamp/wordpress/wp-includes/functions.php on line 817
```

The desired output is `$_SERVER['REQUEST_URI']`. This can be achieved by calling `add_query_arg( NULL, NULL )`