### PR TITLE
use wp_get_current_user

### DIFF
--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -192,8 +192,7 @@ class Discourse {
         $nonce = $sso->getNonce( $payload );
 
         // Current user info
-        global $current_user;
-        get_currentuserinfo();
+        $current_user = wp_get_current_user();
 
         // Map information
         $params = array(


### PR DESCRIPTION
With `'WP_DEBUG'` set to `true`, logging in from Discourse when there is a logged in WordPress user produces this notice:
```
Notice: get_currentuserinfo is deprecated since version 4.5! Use wp_get_current_user() instead. in /Users/scossar/testeleven/wp-mamp/wordpress/wp-includes/functions.php on line 3658
```

`wp_get_current_user` is a wrapper of `get_currentuserinfo` using the global variable `$current_user`