### PR TITLE
FIX: add show-existing-comments option

### DIFF
--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -27,6 +27,7 @@ class Discourse {
     'auto-track' => 1,
     'max-comments' => 5,
     'use-discourse-comments' => 0,
+    'show-existing-comments' => 0,
     'publish-format' => '<small>Originally published at: {blogurl}</small><br>{excerpt}',
     'min-score' => 30,
     'min-replies' => 5,


### PR DESCRIPTION
When `'WP_DEBUG'` is set to 'true' and `'Show Existing WP Comments'` is set to `false` on the WordPress Discourse settings page,  this notice is generated: `Undefined index: show-existing-comments in /Users/scossar/testeleven/wp-mamp/wordpress/wp-content/plugins/wp-discourse/lib/discourse.php on line 329 `. 

This is fixed by adding the key value pair `'show-existing-comments' => 0` to the options array.