### PR TITLE
FIX: name property not available in participants array

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -187,7 +187,7 @@ class DiscourseAdmin {
   }
 
   function template_participant_html() {
-    self::text_area( 'participant-html', 'HTML template to use for each participant<br/>Available tags: <small>{discourse_url}, {discourse_url_name}, {topic_url}, {avatar_url}, {user_url}, {username}, {fullname}</small>' );
+    self::text_area( 'participant-html', 'HTML template to use for each participant<br/>Available tags: <small>{discourse_url}, {discourse_url_name}, {topic_url}, {avatar_url}, {user_url}, {username}</small>' );
   }
 
   function checkbox_input( $option, $label, $description = '' ) {

--- a/templates/comments.php
+++ b/templates/comments.php
@@ -65,7 +65,6 @@ if(count($discourse_info->posts) > 0) {
     $participant_html = str_replace('{avatar_url}', Discourse::avatar($participant->avatar_template,64), $participant_html);
     $participant_html = str_replace('{user_url}', Discourse::homepage($options['url'],$participant), $participant_html);
     $participant_html = str_replace('{username}', $participant->username, $participant_html);
-    $participant_html = str_replace('{fullname}', $participant->name, $participant_html);
     $participants_html .= $participant_html;
   }
   $discourse_html = wp_kses_post($options['replies-html']);


### PR DESCRIPTION
When `'WP_DEBUG'` is set to `true` and there are Discourse comments available for a WordPress post, this notice is generated: `Undefined property: stdClass::$name in /Users/scossar/testeleven/wp-mamp/wordpress/wp-content/plugins/wp-discourse/templates/comments.php on line 68`

Line 68 of the comments template is trying to access the `name` property on the `participants` array. The available properties are `username` and `avatar_template`.  This fix deletes the line that references the `name` property. It also removes the `{fullname}` tag from the list of available tags for the participants template.