### PR TITLE
WIP: validate settings

### DIFF
--- a/css/admin-styles.css
+++ b/css/admin-styles.css
@@ -1,0 +1,16 @@
+/* Highlights errors in settings form inputs */
+
+#setting-error-discourse_url ~ form #discourse_url,
+#setting-error-api_key ~ form #discourse_api-key,
+#setting-error-publish_username ~ form #discourse_publish-username,
+#setting-error-max_comments ~ form #discourse_max-comments,
+#setting-error-min_replies ~ form #discourse_min-replies,
+#setting-error-min_score ~ form #discourse_min-score,
+#setting-error-min_trust_level ~ form #discourse_min-trust-level,
+#setting-error-bypass_trust_level ~ form #discourse_bypass-trust-level-score,
+#setting-error-excerpt_length ~ form #discourse_custom-excerpt-length,
+#setting-error-sso_secret ~ form #discourse_sso-secret {
+    border-color: #dc3232;
+    border-width: 2px;
+}
+

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -137,19 +137,19 @@ class DiscourseAdmin {
   }
 
   function min_replies_input() {
-    self::text_input( 'min-replies', 'Minimum replies required prior to pulling comments across', 'number' );
+    self::text_input( 'min-replies', 'Minimum replies required prior to pulling comments across', 'number', 0 );
   }
 
   function min_trust_level_input() {
-    self::text_input( 'min-trust-level', 'Minimum trust level required prior to pulling comments across (0-5)', 'number' );
+    self::text_input( 'min-trust-level', 'Minimum trust level required prior to pulling comments across (0-5)', 'number', 0 );
   }
 
   function min_score_input() {
-    self::text_input( 'min-score', 'Minimum score required prior to pulling comments across (score = 15 points per like, 5 per reply, 5 per incoming link, 0.2 per read)', 'number' );
+    self::text_input( 'min-score', 'Minimum score required prior to pulling comments across (score = 15 points per like, 5 per reply, 5 per incoming link, 0.2 per read)', 'number', 0 );
   }
 
   function custom_excerpt_length() {
-    self::text_input( 'custom-excerpt-length', 'Custom excerpt length in words (default: 55)', 'number' );
+    self::text_input( 'custom-excerpt-length', 'Custom excerpt length in words (default: 55)', 'number', 0 );
   }
 
   function custom_datetime_format() {
@@ -157,7 +157,7 @@ class DiscourseAdmin {
   }
 
   function bypass_trust_level_input() {
-    self::text_input( 'bypass-trust-level-score', 'Bypass trust level check on posts with this score', 'number' );
+    self::text_input( 'bypass-trust-level-score', 'Bypass trust level check on posts with this score', 'number', 0 );
   }
 
   function debug_mode_checkbox() {
@@ -193,7 +193,7 @@ class DiscourseAdmin {
     if (array_key_exists( $option, $options) and $options[$option] == 1) {
       $value = 'checked="checked"';
     } else {
-      $value = '';
+      $value = '0';
     }
 
     ?>
@@ -296,7 +296,7 @@ class DiscourseAdmin {
     echo '</select>';
   }
 
-  function text_input( $option, $description, $type = null ) {
+  function text_input( $option, $description, $type = null, $min = null ) {
     $options = $this->options;
 
     if ( array_key_exists( $option, $options ) ) {
@@ -306,7 +306,10 @@ class DiscourseAdmin {
     }
 
     ?>
-    <input id='discourse_<?php echo  esc_attr( $option ); ?>' name='discourse[<?php echo esc_attr( $option ); ?>]' type='text' value='<?php echo esc_attr( $value ); ?>' class="regular-text ltr" />
+    <input id='discourse_<?php echo $option?>' name='discourse[<?php echo $option?>]'
+           type="<?php echo isset( $type ) ? $type : 'text'; ?>"
+           <?php if ( isset( $min ) ) echo 'min="' . $min . '"'; ?>
+           value='<?php echo esc_attr( $value ); ?>' class="regular-text ltr" />
     <p class="description"><?php echo esc_html( $description ); ?></p>
     <?php
   }
@@ -328,12 +331,13 @@ class DiscourseAdmin {
   }
 
   function discourse_validate_options( $inputs ) {
+    $output = array();
     foreach ( $inputs as $key => $input ) {
-      $inputs[ $key ] = is_string( $input ) ? trim( $input ) : $input;
+      $filter = 'validate_' . str_replace( '-', '_', $key );
+      $output[$key] = apply_filters( $filter, $input );
     }
 
-    $inputs['url'] = untrailingslashit( $inputs['url'] );
-    return $inputs;
+    return $output;
   }
 
   function discourse_admin_menu() {

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -80,7 +80,7 @@ class Discourse {
 
   public function init() {
     // allow translations
-    load_plugin_textdomain( 'discourse', false, basename( dirname( __FILE__ ) ) . '/languages' );
+    load_plugin_textdomain( 'wp-discourse', false, basename( dirname( __FILE__ ) ) . '/languages' );
 
     // replace comments with discourse comments
     add_filter( 'comments_number', array( $this, 'comments_number' ) );
@@ -93,6 +93,12 @@ class Discourse {
     add_action( 'xmlrpc_publish_post', array( $this, 'xmlrpc_publish_post_to_discourse' ) );
     add_action( 'transition_post_status', array( $this, 'publish_post_to_discourse' ), 10, 3 );
     add_action( 'parse_query', array( $this, 'sso_parse_request' ) );
+    add_action( 'admin_enqueue_scripts', array( $this, 'admin_styles' ) );
+  }
+
+  function admin_styles() {
+    wp_register_style( 'wp_discourse_admin', WPDISCOURSE_URL . '/css/admin-styles.css' );
+    wp_enqueue_style( 'wp_discourse_admin' );
   }
 
   function discourse_comments_js() {

--- a/lib/settings-validator.php
+++ b/lib/settings-validator.php
@@ -1,0 +1,323 @@
+<?php
+namespace WPDiscourse\Validator;
+
+/*
+ * Validation methods for the settings page.
+ *
+ * The methods are invoked by the call to `apply_filters( $filter, $input );`
+ * in `DiscourseAdmin#discourse_validate_options`
+ */
+
+class SettingsValidator {
+
+  protected $sso_enabled = 0;
+  protected $use_discourse_comments = 0;
+
+  public function __construct() {
+    add_filter( 'validate_url', array( $this, 'validate_url' ) );
+    add_filter( 'validate_api_key', array( $this, 'validate_api_key' ) );
+    add_filter( 'validate_publish_username', array(
+      $this,
+      'validate_publish_username'
+    ) );
+    add_filter( 'validate_publish_category', array(
+      $this,
+      'validate_publish_category'
+    ) );
+    add_filter( 'validate_publish_category_update', array(
+      $this,
+      'validate_publish_category_update'
+    ) );
+    add_filter( 'validate_publish_format', array(
+      $this,
+      'validate_publish_format'
+    ) );
+    add_filter( 'validate_full_post_content', array(
+      $this,
+      'validate_full_post_content'
+    ) );
+    add_filter( 'validate_auto_publish', array(
+      $this,
+      'validate_auto_publish'
+    ) );
+    add_filter( 'validate_auto_track', array( $this, 'validate_auto_track' ) );
+    add_filter( 'validate_allowed_post_types', array(
+      $this,
+      'validate_allowed_post_types'
+    ) );
+    add_filter( 'validate_use_discourse_comments', array(
+      $this,
+      'validate_use_discourse_comments'
+    ) );
+    add_filter( 'validate_show_existing_comments', array(
+      $this,
+      'validate_show_existing_comments'
+    ) );
+    add_filter( 'validate_existing_comments_heading', array(
+      $this,
+      'validate_existing_comments_heading'
+    ) );
+    add_filter( 'validate_max_comments', array(
+      $this,
+      'validate_max_comments'
+    ) );
+    add_filter( 'validate_min_replies', array(
+      $this,
+      'validate_min_replies'
+    ) );
+    add_filter( 'validate_min_score', array( $this, 'validate_min_score' ) );
+    add_filter( 'validate_min_trust_level', array(
+      $this,
+      'validate_min_trust_level'
+    ) );
+    add_filter( 'validate_bypass_trust_level_score', array(
+      $this,
+      'validate_bypass_trust_level_score'
+    ) );
+    add_filter( 'validate_custom_excerpt_length', array(
+      $this,
+      'validate_custom_excerpt_length'
+    ) );
+    add_filter( 'validate_custom_datetime_format', array(
+      $this,
+      'validate_custom_datetime_format'
+    ) );
+    add_filter( 'validate_only_show_moderator_liked', array(
+      $this,
+      'validate_only_show_moderator_liked'
+    ) );
+    add_filter( 'validate_replies_html', array(
+      $this,
+      'validate_replies_html'
+    ) );
+    add_filter( 'validate_no_replies_html', array(
+      $this,
+      'validate_no_replies_html'
+    ) );
+    add_filter( 'validate_comment_html', array(
+      $this,
+      'validate_comment_html'
+    ) );
+    add_filter( 'validate_participant_html', array(
+      $this,
+      'validate_participant_html'
+    ) );
+    add_filter( 'validate_debug_mode', array( $this, 'validate_debug_mode' ) );
+    add_filter( 'validate_enable_sso', array( $this, 'validate_enable_sso' ) );
+    add_filter( 'validate_sso_secret', array( $this, 'validate_sso_secret' ) );
+  }
+
+  public function validate_url( $input ) {
+    // URL regex: see https://gist.github.com/gruber/8891611
+    $regex = '$(?i)\b((?:https?:(?:/{1,3}|[a-z0-9%])|[a-z0-9.\-]+[.](?:com|net|org|edu|gov|mil|aero|asia|biz|cat|coop|info|int|jobs|mobi|museum|name|post|pro|tel|travel|xxx|ac|ad|ae|af|ag|ai|al|am|an|ao|aq|ar|as|at|au|aw|ax|az|ba|bb|bd|be|bf|bg|bh|bi|bj|bm|bn|bo|br|bs|bt|bv|bw|by|bz|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|co|cr|cs|cu|cv|cx|cy|cz|dd|de|dj|dk|dm|do|dz|ec|ee|eg|eh|er|es|et|eu|fi|fj|fk|fm|fo|fr|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn|gp|gq|gr|gs|gt|gu|gw|gy|hk|hm|hn|hr|ht|hu|id|ie|il|im|in|io|iq|ir|is|it|je|jm|jo|jp|ke|kg|kh|ki|km|kn|kp|kr|kw|ky|kz|la|lb|lc|li|lk|lr|ls|lt|lu|lv|ly|ma|mc|md|me|mg|mh|mk|ml|mm|mn|mo|mp|mq|mr|ms|mt|mu|mv|mw|mx|my|mz|na|nc|ne|nf|ng|ni|nl|no|np|nr|nu|nz|om|pa|pe|pf|pg|ph|pk|pl|pm|pn|pr|ps|pt|pw|py|qa|re|ro|rs|ru|rw|sa|sb|sc|sd|se|sg|sh|si|sj|Ja|sk|sl|sm|sn|so|sr|ss|st|su|sv|sx|sy|sz|tc|td|tf|tg|th|tj|tk|tl|tm|tn|to|tp|tr|tt|tv|tw|tz|ua|ug|uk|us|uy|uz|va|vc|ve|vg|vi|vn|vu|wf|ws|ye|yt|yu|za|zm|zw)/)(?:[^\s()<>{}\[\]]+|\([^\s()]*?\([^\s()]+\)[^\s()]*?\)|\([^\s]+?\))+(?:\([^\s()]*?\([^\s()]+\)[^\s()]*?\)|\([^\s]+?\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’])|(?:(?<!@)[a-z0-9]+(?:[.\-][a-z0-9]+)*[.](?:com|net|org|edu|gov|mil|aero|asia|biz|cat|coop|info|int|jobs|mobi|museum|name|post|pro|tel|travel|xxx|ac|ad|ae|af|ag|ai|al|am|an|ao|aq|ar|as|at|au|aw|ax|az|ba|bb|bd|be|bf|bg|bh|bi|bj|bm|bn|bo|br|bs|bt|bv|bw|by|bz|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|co|cr|cs|cu|cv|cx|cy|cz|dd|de|dj|dk|dm|do|dz|ec|ee|eg|eh|er|es|et|eu|fi|fj|fk|fm|fo|fr|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn|gp|gq|gr|gs|gt|gu|gw|gy|hk|hm|hn|hr|ht|hu|id|ie|il|im|in|io|iq|ir|is|it|je|jm|jo|jp|ke|kg|kh|ki|km|kn|kp|kr|kw|ky|kz|la|lb|lc|li|lk|lr|ls|lt|lu|lv|ly|ma|mc|md|me|mg|mh|mk|ml|mm|mn|mo|mp|mq|mr|ms|mt|mu|mv|mw|mx|my|mz|na|nc|ne|nf|ng|ni|nl|no|np|nr|nu|nz|om|pa|pe|pf|pg|ph|pk|pl|pm|pn|pr|ps|pt|pw|py|qa|re|ro|rs|ru|rw|sa|sb|sc|sd|se|sg|sh|si|sj|Ja|sk|sl|sm|sn|so|sr|ss|st|su|sv|sx|sy|sz|tc|td|tf|tg|th|tj|tk|tl|tm|tn|to|tp|tr|tt|tv|tw|tz|ua|ug|uk|us|uy|uz|va|vc|ve|vg|vi|vn|vu|wf|ws|ye|yt|yu|za|zm|zw)\b/?(?!@)))$';
+
+    if ( preg_match( $regex, $input ) ) {
+      return esc_url_raw( untrailingslashit( $input ) );
+    } else {
+      add_settings_error( 'discourse', 'discourse_url', __( 'The Discourse URL you provided is not a valid URL.', 'wp-discourse' ) );
+
+      return esc_url_raw( $input );
+    }
+  }
+
+  public function validate_api_key( $input ) {
+    $regex = '/^\s*([0-9]*[a-z]*|[a-z]*[0-9]*)*\s*$/';
+
+    if ( empty( $input ) ) {
+      add_settings_error( 'discourse', 'api_key', __( 'You must provide an API key.', 'wp-discourse' ) );
+
+      return '';
+
+    } elseif ( preg_match( $regex, $input ) ) {
+      return trim( $input );
+
+    } else {
+      add_settings_error( 'discourse', 'api_key', __( 'The API key you provided is not valid.', 'wp-discourse' ) );
+
+      return $this->sanitize_text( $input );
+    }
+  }
+
+  public function validate_publish_username( $input ) {
+    if ( ! empty( $input ) ) {
+      return $this->sanitize_text( $input );
+    } else {
+      add_settings_error( 'discourse', 'publish_username', __( 'You must provide a Discourse username with which to publish the posts', 'wp-discourse' ) );
+
+      return '';
+    }
+  }
+
+  public function validate_publish_category( $input ) {
+    return sanitize_text_field( $input );
+  }
+
+  public function validate_publish_category_update( $input ) {
+    return $this->sanitize_checkbox( $input );
+  }
+
+  public function validate_publish_format( $input ) {
+    return $this->sanitize_html( $input );
+  }
+
+  public function validate_full_post_content( $input ) {
+    return $this->sanitize_checkbox( $input );
+  }
+
+  public function validate_auto_publish( $input ) {
+    return $this->sanitize_checkbox( $input );
+  }
+
+  public function validate_auto_track( $input ) {
+    return $this->sanitize_checkbox( $input );
+  }
+
+  public function validate_allowed_post_types( $input ) {
+    $output = array();
+    foreach ( $input as $post_type ) {
+      $output[] = sanitize_text_field( $post_type );
+    }
+
+    return $output;
+  }
+
+  public function validate_use_discourse_comments( $input ) {
+    $this->use_discourse_comments = ( $input == 1 ) ? 1 : 0;
+
+    return $this->sanitize_checkbox( $input );
+  }
+
+  public function validate_show_existing_comments( $input ) {
+    return $this->sanitize_checkbox( $input );
+  }
+
+  public function validate_existing_comments_heading( $input ) {
+    return $this->sanitize_html( $input );
+  }
+
+  public function validate_max_comments( $input ) {
+    return $this->validate_int( $input, 'max_comments', 1, null,
+      __( 'The max visible comments setting requires a positive integer.', 'wp-discourse' ),
+      $this->use_discourse_comments );
+  }
+
+  public function validate_min_replies( $input ) {
+    return $this->validate_int( $input, 'min_replies', 0, null,
+      __( 'The min number of replies setting requires a number greater than or equal to 0.', 'wp-discourse' ),
+      $this->use_discourse_comments );
+  }
+  
+  public function validate_min_score( $input ) {
+    return $this->validate_int( $input, 'min_score', 0, null,
+      __( 'The min score of posts setting requires a number greater than or equal to 0.', 'wp-discourse' ),
+      $this->use_discourse_comments );
+  }
+
+
+  public function validate_min_trust_level( $input ) {
+    return $this->validate_int( $input, 'min_trust_level', 0, 5,
+      __( 'The trust level setting requires a number between 0 and 5.', 'wp-discourse' ),
+      $this->use_discourse_comments );
+  }
+
+  public function validate_bypass_trust_level_score( $input ) {
+    return $this->validate_int( $input, 'bypass_trust_level', 0, null,
+      __( 'The bypass trust level score setting requires an integer greater than or equal to 0.', 'wp-discourse' ),
+      $this->use_discourse_comments );
+  }
+
+  public function validate_custom_excerpt_length( $input ) {
+    return $this->validate_int( $input, 'excerpt_length', 1, null,
+      __( 'The custom excerpt length setting requires a positive integer.', 'wp-discourse' ),
+      $this->use_discourse_comments );
+  }
+
+  // Tricky to validate. We could show the user an example of what their format translates into.
+  public function validate_custom_datetime_format( $input ) {
+    return sanitize_text_field( $input );
+  }
+
+  public function validate_only_show_moderator_liked( $input ) {
+    return $this->sanitize_checkbox( $input );
+  }
+
+  public function validate_replies_html( $input ) {
+    return $this->sanitize_html( $input );
+  }
+
+  public function validate_no_replies_html( $input ) {
+    return $this->sanitize_html( $input );
+  }
+
+  public function validate_comment_html( $input ) {
+    return $this->sanitize_html( $input );
+  }
+
+  public function validate_participant_html( $input ) {
+    return $this->sanitize_html( $input );
+  }
+
+  public function validate_debug_mode( $input ) {
+    return $this->sanitize_html( $input );
+  }
+
+  public function validate_enable_sso( $input ) {
+    $this->sso_enabled = ( $input == 1 ) ? 1 : 0;
+
+    return $this->sanitize_checkbox( $input );
+  }
+
+  public function validate_sso_secret( $input ) {
+    if ( strlen( sanitize_text_field( $input) ) >= 10 ) {
+      return sanitize_text_field( $input );
+      
+      // Only add a settings error if sso is enabled, otherwise just sanitize the input.
+    } elseif ( $this->sso_enabled ) {
+      add_settings_error( 'discourse', 'sso_secret', __( 'The SSO secret key setting must be at least 10 characters long.', 'wp-discourse' ) );
+
+      return sanitize_text_field( $input );
+
+    } else {
+      return sanitize_text_field( $input );
+    }
+  }
+
+  // Helper methods
+
+  protected function sanitize_text( $input ) {
+    return sanitize_text_field( $input );
+  }
+
+  protected function sanitize_checkbox( $input ) {
+    return $input == 1 ? 1 : 0;
+  }
+
+  protected function sanitize_html( $input ) {
+    return wp_kses_post( $input );
+  }
+
+  protected function validate_int( $input, $option_id, $min = null, $max = null, $error_message = '', $add_error = 1 ) {
+    $options = array();
+
+    if ( isset( $min ) ) {
+      $options['min_range'] = $min;
+    }
+    if ( isset( $max ) ) {
+      $options['max_range'] = $max;
+    }
+
+    if ( filter_var( $input, FILTER_VALIDATE_INT, array( 'options' => $options ) ) === false ) {
+      if ( $add_error ) {
+        add_settings_error( 'discourse', $option_id, $error_message );
+        
+        return filter_var( $input, FILTER_SANITIZE_NUMBER_INT );
+      }
+
+      // The input is not valid, but the setting's section is not being used, sanitize the input and return it.
+      return filter_var( $input, FILTER_SANITIZE_NUMBER_INT );
+    } else {
+      // Valid input
+      return filter_var( $input, FILTER_SANITIZE_NUMBER_INT );
+    }
+  }
+}

--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -4,6 +4,8 @@ Plugin Name: WP-Discourse
 Description: Use Discourse as a community engine for your WordPress blog
 Version: 0.6.6
 Author: Sam Saffron, Robin Ward
+Text Domain: wp-discourse
+Domain Path: /languages
 Author URI: https://github.com/discourse/wp-discourse
 Plugin URI: https://github.com/discourse/wp-discourse
 GitHub Plugin URI: https://github.com/discourse/wp-discourse
@@ -29,10 +31,12 @@ define( 'WPDISCOURSE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WPDISCOURSE_URL', plugins_url( '', __FILE__ ) );
 
 require_once( __DIR__ . '/lib/discourse.php' );
+require_once( __DIR__ . '/lib/settings-validator.php' );
 require_once( __DIR__ . '/lib/admin.php' );
 require_once( __DIR__ . '/lib/sso.php' );
 
 $discourse = new Discourse();
+$discourse_settings_validator = new WPDiscourse\Validator\SettingsValidator();
 $discourse_admin = new DiscourseAdmin();
 
 register_activation_hook( __FILE__, array( $discourse, 'install' ) );


### PR DESCRIPTION
Adds a SettingsValidator class. The settings are invoked by a call to `apply_filters( $filter, $input );` from `DiscourseAdmin#discourse_validate_options`. Error messages are added to the settings page to give the user a bit of feedback:

![screenshot 2016-05-12 16 02 04](https://cloud.githubusercontent.com/assets/2975917/15233212/d49fc5ba-185b-11e6-92b5-714b5f56a6df.png)

I would like to add some tests for the validation. I want to make sure that this work is on the right track before I do that.

I have changed the plugin's text domain from `discourse` to `wp-discourse`. 
