### PR TITLE
FIX: use cached categories when there is a configuration error

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -244,7 +244,7 @@ class DiscourseAdmin {
       $invalid_response = wp_remote_retrieve_response_code( $remote ) != 200;
 
       if ( is_wp_error( $remote ) || $invalid_response ) {
-        if ( array_key_exists( 'category_list', $cache ) ) {
+        if ( ! empty( $cache ) ) {
           $categories = $cache['category_list']['categories'];
           return $categories;
         } else {

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -248,15 +248,14 @@ class DiscourseAdmin {
           $categories = $cache['category_list']['categories'];
           return $categories;
         } else {
-          // We're not going to get anything useful by returning $remote.
-          return null;
+          return new WP_Error( 'connection_not_established', 'There was an error establishing a connection with Discourse' );
         }
       }
 
       $remote = wp_remote_retrieve_body( $remote );
 
       if( is_wp_error( $remote ) ) {
-        return null;
+        return $remote;
       }
 
       $remote = json_decode( $remote, true );


### PR DESCRIPTION
Currently, when there is an error with the `api key` or `publishing username` settings, the `get_discourse_categories` method is generating the notice: 'Undefined index: category_list'. This is happening because a `WP_Error` isn't being generated. This PR adds a check for the status code of the response.

If the force update setting is enabled, and there is an error, and there are cached categories, this PR returns those categories. Previously, the cached categories were being passed through `wp_remote_retrieve_body` and `json_decode` and `set_transient`.

~~In the case where there is an error, but no cache, I'm just returning `null` instead of returning the value stored in `$remote`.~~