### PR TITLE
WIP: add notices to indicate connection status

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -403,7 +403,7 @@ class DiscourseAdmin {
     ?>
     <div class="notice notice-warning is-dismissible">
       <p>
-        <strong><?php _e( "You are not currently connected to a Discourse forum. Check your settings for 'Discourse Url', 'API Key', and 'Publishing username'. ", 'wp-discourse' ); ?></strong>
+        <strong><?php _e( "You are not currently connected to a Discourse forum. Check your settings for 'Discourse URL', 'API Key', and 'Publishing username'. ", 'wp-discourse' ); ?></strong>
       </p>
     </div>
     <?php


### PR DESCRIPTION
Hooks into the `load-settings(page)` action to test the supplied api credentials (url, api-key, username).
Adds success and warning messages to indicate the connection status.

![screenshot 2016-05-14 10 35 37](https://cloud.githubusercontent.com/assets/2975917/15269810/2343bce8-19c0-11e6-8946-1202298fe202.png)

![screenshot 2016-05-14 10 36 13](https://cloud.githubusercontent.com/assets/2975917/15269813/2928e2d2-19c0-11e6-8715-564204364ca6.png)
