### PR TITLE
WIP: Move templates out of options

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -22,7 +22,7 @@ class DiscourseAdmin {
     add_settings_section( 'discourse_wp_api', 'Common Settings', array( $this, 'init_default_settings' ), 'discourse' );
 
     add_settings_section( 'discourse_wp_publish', 'Publishing Settings', array( $this, 'init_default_settings' ), 'discourse' );
-    add_settings_section( 'discourse_comments', 'Comments Settings', array( $this, 'init_default_settings' ), 'discourse' );
+    add_settings_section( 'discourse_comments', 'Comments Settings', array( $this, 'init_comment_settings' ), 'discourse' );
     add_settings_section( 'discourse_wp_sso', 'SSO Settings', array( $this, 'init_default_settings' ), 'discourse' );
 
     add_settings_field( 'discourse_url', 'Discourse URL', array( $this, 'url_input' ), 'discourse', 'discourse_wp_api' );
@@ -34,7 +34,6 @@ class DiscourseAdmin {
 
     add_settings_field( 'discourse_publish_category', 'Published category', array( $this, 'publish_category_input' ), 'discourse', 'discourse_wp_publish' );
     add_settings_field( 'discourse_publish_category_update', 'Force category update', array( $this, 'publish_category_input_update' ), 'discourse', 'discourse_wp_publish' );
-    add_settings_field( 'discourse_publish_format', 'Publish format', array( $this, 'publish_format_textarea' ), 'discourse', 'discourse_wp_publish' );
     add_settings_field( 'discourse_full_post_content', 'Use full post content', array( $this, 'full_post_checkbox' ), 'discourse', 'discourse_wp_publish' );
 
     add_settings_field( 'discourse_auto_publish', 'Auto Publish', array( $this, 'auto_publish_checkbox' ), 'discourse', 'discourse_wp_publish' );
@@ -53,10 +52,6 @@ class DiscourseAdmin {
     add_settings_field( 'discourse_custom_datetime_format', 'Custom Datetime Format', array( $this, 'custom_datetime_format' ), 'discourse', 'discourse_comments' );
 
     add_settings_field( 'discourse_only_show_moderator_liked', 'Only import comments liked by a moderator', array( $this, 'only_show_moderator_liked_checkbox' ), 'discourse', 'discourse_comments' );
-    add_settings_field( 'discourse_template_replies', 'HTML Template to use when there are replies', array( $this, 'template_replies_html' ), 'discourse', 'discourse_comments' );
-    add_settings_field( 'discourse_template_no_replies', 'HTML Template to use when there are no replies', array( $this, 'template_no_replies_html' ), 'discourse', 'discourse_comments' );
-    add_settings_field( 'discourse_template_comment', 'HTML Template to use for each comment', array( $this, 'template_comment_html' ), 'discourse', 'discourse_comments' );
-    add_settings_field( 'discourse_participant_comment', 'HTML Template to use for each participant', array( $this, 'template_participant_html' ), 'discourse', 'discourse_comments' );
     add_settings_field( 'discourse_debug_mode', 'Debug mode', array( $this, 'debug_mode_checkbox' ), 'discourse', 'discourse_comments' );
 
     add_action( 'post_submitbox_misc_actions', array( $this, 'publish_to_discourse' ) );
@@ -69,7 +64,19 @@ class DiscourseAdmin {
     return $fields;
   }
 
-  function init_default_settings() {}
+  function init_default_settings() {
+  }
+
+  function init_comment_settings() {
+    ?>
+
+    <p class="documentation-link">
+      <em><?php _e( 'For documentation on customizing the plugin\'s html, visit ', 'wp-discourse'); ?></em>
+      <a href="https://github.com/scossar/wp-discourse/wiki/Template-Customization">https://github.com/scossar/wp-discourse/wiki/Template-Customization</a>
+    </p>
+
+    <?php
+  }
 
   function url_input() {
     self::text_input( 'url', 'e.g. http://discourse.example.com', 'url' );
@@ -102,10 +109,6 @@ class DiscourseAdmin {
 
   function publish_category_input_update() {
     self::checkbox_input( 'publish-category-update', 'Update the discourse publish category list, normaly set for an hour (normaly set to refresh every hour)' );
-  }
-
-  function publish_format_textarea() {
-    self::text_area( 'publish-format', 'Markdown format for published articles, use {excerpt} for excerpt and {blogurl} for the url of the blog post' );
   }
 
   function max_comments_input() {
@@ -170,22 +173,6 @@ class DiscourseAdmin {
 
   function only_show_moderator_liked_checkbox() {
     self::checkbox_input( 'only-show-moderator-liked', 'Yes' );
-  }
-
-  function template_replies_html() {
-    self::text_area( 'replies-html', 'HTML template to use when there are replies<br/>Available tags: <small>{comments}, {discourse_url}, {discourse_url_name}, {topic_url}, {more_replies}, {participants}</small>' );
-  }
-
-  function template_no_replies_html() {
-    self::text_area( 'no-replies-html', 'HTML template to use when there are no replies<br/>Available tags: <small>{comments}, {discourse_url}, {discourse_url_name}, {topic_url}</small>' );
-  }
-
-  function template_comment_html() {
-    self::text_area( 'comment-html', 'HTML template to use for each comment<br/>Available tags: <small>{discourse_url}, {discourse_url_name}, {topic_url}, {avatar_url}, {user_url}, {username}, {fullname}, {comment_body}, {comment_created_at}</small>' );
-  }
-
-  function template_participant_html() {
-    self::text_area( 'participant-html', 'HTML template to use for each participant<br/>Available tags: <small>{discourse_url}, {discourse_url_name}, {topic_url}, {avatar_url}, {user_url}, {username}</small>' );
   }
 
   function checkbox_input( $option, $label, $description = '' ) {
@@ -281,7 +268,7 @@ class DiscourseAdmin {
    $name = "discourse[$option]";
    self::option_input($name, $categories, $selected);
   }
-  
+
   function option_input( $name, $group, $selected ) {
     echo '<select id="' . esc_attr( $name ) . '" name="' . esc_attr( $name ) . '">';
 
@@ -351,6 +338,10 @@ class DiscourseAdmin {
     ?>
     <div class="wrap">
       <h2>Discourse Options</h2>
+      <p class="documentation-link">
+        <em><?php _e( 'The WP Discourse plugin documentation can be found at ', 'wp-discourse'); ?></em>
+        <a href="https://github.com/scossar/wp-discourse/wiki">https://github.com/scossar/wp-discourse/wiki</a>
+      </p>
       <form action="options.php" method="POST">
         <?php settings_fields( 'discourse' ); ?>
         <?php do_settings_sections( 'discourse' ); ?>

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -72,7 +72,7 @@ class DiscourseAdmin {
 
     <p class="documentation-link">
       <em><?php _e( 'For documentation on customizing the plugin\'s html, visit ', 'wp-discourse'); ?></em>
-      <a href="https://github.com/scossar/wp-discourse/wiki/Template-Customization">https://github.com/scossar/wp-discourse/wiki/Template-Customization</a>
+      <a href="https://github.com/discourse/wp-discourse/wiki/Template-Customization">https://github.com/discourse/wp-discourse/wiki/Template-Customization</a>
     </p>
 
     <?php
@@ -340,7 +340,7 @@ class DiscourseAdmin {
       <h2>Discourse Options</h2>
       <p class="documentation-link">
         <em><?php _e( 'The WP Discourse plugin documentation can be found at ', 'wp-discourse'); ?></em>
-        <a href="https://github.com/scossar/wp-discourse/wiki">https://github.com/scossar/wp-discourse/wiki</a>
+        <a href="https://github.com/discourse/wp-discourse/wiki">https://github.com/discourse/wp-discourse/wiki</a>
       </p>
       <form action="options.php" method="POST">
         <?php settings_fields( 'discourse' ); ?>

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -2,6 +2,8 @@
 /**
  * WP-Discourse
  */
+use WPDiscourse\Templates as Templates;
+
 class Discourse {
   public static function homepage( $url, $post ) {
     return $url . "/users/" . strtolower( $post->username );
@@ -28,7 +30,6 @@ class Discourse {
     'max-comments' => 5,
     'use-discourse-comments' => 0,
     'show-existing-comments' => 0,
-    'publish-format' => '<small>Originally published at: {blogurl}</small><br>{excerpt}',
     'min-score' => 30,
     'min-replies' => 5,
     'min-trust-level' => 1,
@@ -36,37 +37,7 @@ class Discourse {
     'bypass-trust-level-score' => 50,
     'debug-mode' => 0,
     'full-post-content' => 0,
-    'only-show-moderator-liked' => 0,
-    'replies-html' => '<div id="comments" class="comments-area">
-  <h2 class="comments-title">Notable Replies</h2>
-  <ol class="comment-list">{comments}</ol>
-  <div class="respond" class="comment-respond">
-    <h3 id="reply-title" class="comment-reply-title"><a href="{topic_url}">Continue the discussion</a> at {discourse_url_name}</h3>
-    <p class="more-replies">{more_replies}</p>
-    <p class="comment-reply-title">{participants}</p>
-  </div><!-- #respond -->
-</div>',
-      'no-replies-html' => '<div id="comments" class="comments-area">
-  <div class="respond" class="comment-respond">
-    <h3 id="reply-title" class="comment-reply-title"><a href="{topic_url}">Start the discussion</a> at {discourse_url_name}</h3>
-  </div><!-- #respond -->
- </div>',
-      'comment-html' => '<li class="comment even thread-even depth-1">
-  <article class="comment-body">
-    <footer class="comment-meta">
-      <div class="comment-author vcard">
-        <img alt="" src="{avatar_url}" class="avatar avatar-64 photo avatar-default" height="64" width="64">
-        <b class="fn"><a href="{topic_url}" rel="external" class="url">{fullname}</a></b>
-        <span class="says">says:</span>
-      </div><!-- .comment-author -->
-      <div class="comment-metadata">
-        <time pubdate="" datetime="{comment_created_at}">{comment_created_at}</time>
-      </div><!-- .comment-metadata -->
-    </footer><!-- .comment-meta -->
-    <div class="comment-content">{comment_body}</div><!-- .comment-content -->
-  </article><!-- .comment-body -->
-</li>',
-      'participant-html' => '<img alt="" src="{avatar_url}" class="avatar avatar-25 photo avatar-default" height="25" width="25">'
+    'only-show-moderator-liked' => 0
   );
 
   public function __construct() {
@@ -459,7 +430,8 @@ class Discourse {
       $excerpt = discourse_custom_excerpt( $postid );
     }
 
-    $baked = $options['publish-format'];
+    // trim to keep the Discourse markdown parser from treating this as code.
+    $baked = trim( Templates\HTMLTemplates::publish_format_html() );
     $baked = str_replace( "{excerpt}", $excerpt, $baked );
     $baked = str_replace( "{blogurl}", get_permalink( $postid ), $baked );
     $author_id = $post->post_author;

--- a/lib/html-templates.php
+++ b/lib/html-templates.php
@@ -1,0 +1,150 @@
+<?php
+namespace WPDiscourse\Templates;
+
+/**
+ * Class HTMLTemplates
+ *
+ * Static methods to return HTML templates. Used in `templates/comments.php`
+ *
+ * Templates and implementation copied from @aliso's commit:
+ * https://github.com/10up/wp-discourse/commit/5c9d43c4333e136204d5a3b07192f4b368c3f518
+ */
+class HTMLTemplates {
+
+  /**
+   * HTML template for replies
+   *
+   * Can be customized from within a theme using the filter provided.
+   *
+   * Available tags:
+   * {comments}, {discourse_url}, {discourse_url_name},
+   * {topic_url}, {more_replies}, {participants}
+   *
+   * @static
+   * @return mixed|void
+   */
+  public static function replies_html() {
+    ob_start();
+    ?>
+    <div id="comments" class="comments-area">
+      <h2 class="comments-title">Notable Replies</h2>
+      <ol class="comment-list">{comments}</ol>
+      <div class="respond comment-respond">
+        <h3 id="reply-title" class="comment-reply-title">
+          <a href="{topic_url}">Continue the discussion at</a> at {discourse_url_name}
+        </h3>
+        <p class="more-replies">{more_replies}</p>
+        <p class="comment-reply-title">{participants}</p>
+      </div><!-- #respond -->
+    </div>
+    <?php
+    $output = ob_get_clean();
+    return apply_filters( 'discourse_replies_html', $output );
+  }
+
+  /**
+   * HTML template for no replies
+   *
+   * Can be customized from within a theme using the filter provided.
+   *
+   * Available tags:
+   * {comments}, {discourse_url}, {discourse_url_name}, {topic_url}
+   *
+   * @static
+   * @return mixed|void
+   */
+  public static function no_replies_html() {
+    ob_start();
+    ?>
+    <div id="comments" class="comments-area">
+      <div class="respond comment-respond">
+        <h3 id="reply-title" class="comment-reply-title"><a href="{topic_url}">Start the discussion</a> at {discourse_url_name}</h3>
+      </div><!-- #respond -->
+    </div>
+    <?php
+    $output = ob_get_clean();
+    return apply_filters( 'discourse_no_replies_html', $output );
+  }
+
+  /**
+   * HTML template for each comment
+   *
+   * Can be customized from within a theme using the filter provided.
+   *
+   * Available tags:
+   * {discourse_url}, {discourse_url_name}, {topic_url},
+   * {avatar_url}, {user_url}, {username}, {fullname},
+   * {comment_body}, {comment_created_at}, {comment_url}
+   *
+   * @static
+   * @return mixed|void
+   */
+  public static function comment_html() {
+    ob_start();
+    ?>
+    <li class="comment even thread-even depth-1">
+      <article class="comment-body">
+        <footer class="comment-meta">
+          <div class="comment-author vcard">
+            <img alt="" src="{avatar_url}" class="avatar avatar-64 photo avatar-default" height="64" width="64">
+            <b class="fn"><a href="{topic_url}" rel="external" class="url">{fullname}</a></b>
+            <span class="says">says:</span>
+          </div>
+          <!-- .comment-author -->
+          <div class="comment-metadata">
+            <time pubdate="" datetime="{comment_created_at}">{comment_created_at}</time>
+          </div>
+          <!-- .comment-metadata -->
+        </footer>
+        <!-- .comment-meta -->
+        <div class="comment-content">{comment_body}</div>
+        <!-- .comment-content -->
+      </article>
+      <!-- .comment-body -->
+    </li>
+    <?php
+    $output = ob_get_clean();
+    return apply_filters( 'discourse_comment_html', $output );
+  }
+
+  /**
+   * HTML template for each participant
+   *
+   * Can be customized from within a theme using the filter provided.
+   *
+   * Available tags:
+   * {discourse_url}, {discourse_url_name}, {topic_url},
+   * {avatar_url}, {user_url}, {username}
+   *
+   * @static
+   * @return mixed|void
+   */
+  public static function participant_html() {
+    ob_start();
+    ?>
+    <img alt="" src="{avatar_url}" class="avatar avatar-25 photo avatar-default" height="25" width="25">
+    <?php
+    $output = ob_get_clean();
+    return apply_filters( 'discourse_participant_html', $output );
+  }
+
+  /**
+   * HTML template for published byline
+   *
+   * Can be customized from within a theme using the filter provided.
+   *
+   * Available tags:
+   * {excerpt}, {blogurl}, {author}, {thumbnail}, {featuredimage}
+   *
+   * @static
+   * @return mixed|void
+   */
+  public static function publish_format_html() {
+    ob_start();
+    ?>
+    <small>Originally published at: {blogurl}</small><br>{excerpt}
+    <?php
+    $output = ob_get_clean();
+    return apply_filters( 'discourse_publish_format_html', $output );
+  }
+}

--- a/templates/comments.php
+++ b/templates/comments.php
@@ -1,10 +1,12 @@
 <?php
-$custom        = get_post_custom();
-$options       = get_option( 'discourse' );
-$is_enable_sso = ( isset( $options['enable-sso'] ) && intval( $options['enable-sso'] ) == 1 );
-$permalink     = esc_url( $custom['discourse_permalink'][0] );
-if ( $is_enable_sso ) {
-  $permalink = esc_url( $options['url'] ) . '/session/sso?return_path=' . $permalink;
+use WPDiscourse\Templates as Templates;
+
+$custom = get_post_custom();
+$options = get_option('discourse');
+$is_enable_sso = (isset( $options['enable-sso'] ) && intval( $options['enable-sso'] ) == 1);
+$permalink = (string)$custom['discourse_permalink'][0];
+if($is_enable_sso) {
+  $permalink = esc_url($options['url']) . '/session/sso?return_path=' . $permalink;
 }
 $discourse_url_name = preg_replace( "(https?://)", "", esc_url( $options['url'] ) );
 if ( isset( $custom['discourse_comments_raw'] ) ) {
@@ -46,7 +48,7 @@ $participants_html = '';
 
 if ( count( $discourse_info->posts ) > 0 ) {
   foreach ( $discourse_info->posts as &$post ) {
-    $comment_html = wp_kses_post( $options['comment-html'] );
+    $comment_html = wp_kses_post( Templates\HTMLTemplates::comment_html() );
     $comment_html = str_replace( '{discourse_url}', $discourse_url, $comment_html );
     $comment_html = str_replace( '{discourse_url_name}', $discourse_url_name, $comment_html );
     $comment_html = str_replace( '{topic_url}', $permalink, $comment_html );
@@ -62,7 +64,7 @@ if ( count( $discourse_info->posts ) > 0 ) {
     $comments_html .= $comment_html;
   }
   foreach ( $discourse_info->participants as &$participant ) {
-    $participant_html = wp_kses_post( $options['participant-html'] );
+    $participant_html = wp_kses_post( Templates\HTMLTemplates::participant_html() );
     $participant_html = str_replace( '{discourse_url}', $discourse_url, $participant_html );
     $participant_html = str_replace( '{discourse_url_name}', $discourse_url_name, $participant_html );
     $participant_html = str_replace( '{topic_url}', $permalink, $participant_html );
@@ -73,10 +75,10 @@ if ( count( $discourse_info->posts ) > 0 ) {
     $participant_html = str_replace( '{username}', esc_html( $participant->username ), $participant_html );
     $participants_html .= $participant_html;
   }
-  $discourse_html = wp_kses_post( $options['replies-html'] );
+  $discourse_html = wp_kses_post( Templates\HTMLTemplates::replies_html() );
   $discourse_html = str_replace( '{more_replies}', $more_replies, $discourse_html );
 } else {
-  $discourse_html = wp_kses_post( $options['no-replies-html'] );
+  $discourse_html = wp_kses_post( Templates\HTMLTemplates::no_replies_html() );
 }
 $discourse_html = str_replace( '{discourse_url}', $discourse_url, $discourse_html );
 $discourse_html = str_replace( '{discourse_url_name}', $discourse_url_name, $discourse_html );

--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -7,6 +7,8 @@ Author: Sam Saffron, Robin Ward
 Text Domain: wp-discourse
 Domain Path: /languages
 Author URI: https://github.com/discourse/wp-discourse
+Text Domain: wp-discourse
+Domain Path: /languages
 Plugin URI: https://github.com/discourse/wp-discourse
 GitHub Plugin URI: https://github.com/discourse/wp-discourse
 */
@@ -30,6 +32,7 @@ GitHub Plugin URI: https://github.com/discourse/wp-discourse
 define( 'WPDISCOURSE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WPDISCOURSE_URL', plugins_url( '', __FILE__ ) );
 
+require_once( __DIR__ . '/lib/html-templates.php' );
 require_once( __DIR__ . '/lib/discourse.php' );
 require_once( __DIR__ . '/lib/settings-validator.php' );
 require_once( __DIR__ . '/lib/admin.php' );


### PR DESCRIPTION
Based on this commit to the 10up fork of wp-discourse: https://github.com/10up/wp-discourse/commit/5c9d43c4333e136204d5a3b07192f4b368c3f518

This PR moves the html templates out of the plugin's options. If this is implemented, html templates will no longer be customizable through the options page. They can be customized through the theme using the filters that are applied to each function. A link to the documentation of how to do that is added to the settings page. Here is a tentative version: <https://github.com/scossar/wp-discourse/wiki/Template-Customization>

This PR also changes the plugin's text-domain from `discourse` to `wp-discourse`.