### PR TITLE
FIX: allow link in api key description

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -285,6 +285,12 @@ class DiscourseAdmin {
 
   function text_input( $option, $description, $type = null, $min = null ) {
     $options = $this->options;
+    $allowed = array(
+      'a' => array(
+        'href' => array(),
+        'target' => array()
+      )
+    );
 
     if ( array_key_exists( $option, $options ) ) {
       $value = $options[$option];
@@ -297,7 +303,7 @@ class DiscourseAdmin {
            type="<?php echo isset( $type ) ? $type : 'text'; ?>"
            <?php if ( isset( $min ) ) echo 'min="' . $min . '"'; ?>
            value='<?php echo esc_attr( $value ); ?>' class="regular-text ltr" />
-    <p class="description"><?php echo esc_html( $description ); ?></p>
+    <p class="description"><?php echo wp_kses( $description, $allowed ); ?></p>
     <?php
   }
 


### PR DESCRIPTION
Don't escape the link in the api key description.

We want this:

![screenshot 2016-05-18 16 34 15](https://cloud.githubusercontent.com/assets/2975917/15378240/88cf134c-1d16-11e6-93b1-6710af781332.png)

Not this:

![screenshot 2016-05-18 16 34 56](https://cloud.githubusercontent.com/assets/2975917/15378245/93fb8a8e-1d16-11e6-8e72-26f696443aa8.png)


