### PR TITLE
FEATURE[WIP]: Improve WooCommerce support

### DIFF
--- a/css/admin-styles.css
+++ b/css/admin-styles.css
@@ -9,7 +9,8 @@
 #setting-error-min_trust_level ~ form #discourse_min-trust-level,
 #setting-error-bypass_trust_level ~ form #discourse_bypass-trust-level-score,
 #setting-error-excerpt_length ~ form #discourse_custom-excerpt-length,
-#setting-error-sso_secret ~ form #discourse_sso-secret {
+#setting-error-sso_secret ~ form #discourse_sso-secret,
+#setting-error-login_path ~ form #discourse_login-path {
     border-color: #dc3232;
     border-width: 2px;
 }

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -23,6 +23,7 @@ class DiscourseAdmin {
 
     add_settings_section( 'discourse_wp_publish', 'Publishing Settings', array( $this, 'init_default_settings' ), 'discourse' );
     add_settings_section( 'discourse_comments', 'Comments Settings', array( $this, 'init_comment_settings' ), 'discourse' );
+    add_settings_section( 'discourse_plugin_support', 'Plugin Support', array( $this, 'init_default_settings' ), 'discourse' ); 
     add_settings_section( 'discourse_wp_sso', 'SSO Settings', array( $this, 'init_default_settings' ), 'discourse' );
 
     add_settings_field( 'discourse_url', 'Discourse URL', array( $this, 'url_input' ), 'discourse', 'discourse_wp_api' );
@@ -39,6 +40,8 @@ class DiscourseAdmin {
     add_settings_field( 'discourse_auto_publish', 'Auto Publish', array( $this, 'auto_publish_checkbox' ), 'discourse', 'discourse_wp_publish' );
     add_settings_field( 'discourse_auto_track', 'Auto Track Published Topics', array( $this, 'auto_track_checkbox' ), 'discourse', 'discourse_wp_publish' );
     add_settings_field( 'discourse_allowed_post_types', 'Post Types to publish to Discourse', array( $this, 'post_types_select' ), 'discourse', 'discourse_wp_publish' );
+    
+    add_settings_field( 'discourse_woocommerce_support', 'Add WooCommerce support', array( $this, 'woocommerce_support'), 'discourse', 'discourse_plugin_support' );
 
     add_settings_field( 'discourse_use_discourse_comments', 'Use Discourse Comments', array( $this, 'use_discourse_comments_checkbox' ), 'discourse', 'discourse_comments' );
     add_settings_field( 'discourse_show_existing_comments', 'Show Existing WP Comments', array( $this, 'show_existing_comments_checkbox' ), 'discourse', 'discourse_comments' );
@@ -173,6 +176,10 @@ class DiscourseAdmin {
 
   function only_show_moderator_liked_checkbox() {
     self::checkbox_input( 'only-show-moderator-liked', 'Yes' );
+  }
+  
+  function woocommerce_support() {
+    self::checkbox_input( 'woocommerce-support', 'Enable support for the Woocommerce plugin' );
   }
 
   function checkbox_input( $option, $label, $description = '' ) {

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -23,7 +23,6 @@ class DiscourseAdmin {
 
     add_settings_section( 'discourse_wp_publish', 'Publishing Settings', array( $this, 'init_default_settings' ), 'discourse' );
     add_settings_section( 'discourse_comments', 'Comments Settings', array( $this, 'init_comment_settings' ), 'discourse' );
-    add_settings_section( 'discourse_plugin_support', 'Plugin Support', array( $this, 'init_default_settings' ), 'discourse' );
     add_settings_section( 'discourse_wp_sso', 'SSO Settings', array( $this, 'init_default_settings' ), 'discourse' );
 
     add_settings_field( 'discourse_url', 'Discourse URL', array( $this, 'url_input' ), 'discourse', 'discourse_wp_api' );
@@ -41,8 +40,6 @@ class DiscourseAdmin {
     add_settings_field( 'discourse_auto_publish', 'Auto Publish', array( $this, 'auto_publish_checkbox' ), 'discourse', 'discourse_wp_publish' );
     add_settings_field( 'discourse_auto_track', 'Auto Track Published Topics', array( $this, 'auto_track_checkbox' ), 'discourse', 'discourse_wp_publish' );
     add_settings_field( 'discourse_allowed_post_types', 'Post Types to publish to Discourse', array( $this, 'post_types_select' ), 'discourse', 'discourse_wp_publish' );
-
-    add_settings_field( 'discourse_woocommerce_support', 'Add WooCommerce support', array( $this, 'woocommerce_support'), 'discourse', 'discourse_plugin_support' );
 
     add_settings_field( 'discourse_use_discourse_comments', 'Use Discourse Comments', array( $this, 'use_discourse_comments_checkbox' ), 'discourse', 'discourse_comments' );
     add_settings_field( 'discourse_show_existing_comments', 'Show Existing WP Comments', array( $this, 'show_existing_comments_checkbox' ), 'discourse', 'discourse_comments' );
@@ -181,10 +178,6 @@ class DiscourseAdmin {
 
   function only_show_moderator_liked_checkbox() {
     self::checkbox_input( 'only-show-moderator-liked', 'Yes' );
-  }
-
-  function woocommerce_support() {
-    self::checkbox_input( 'woocommerce-support', 'Enable support for the Woocommerce plugin' );
   }
 
   function checkbox_input( $option, $label, $description = '' ) {

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -23,7 +23,7 @@ class DiscourseAdmin {
 
     add_settings_section( 'discourse_wp_publish', 'Publishing Settings', array( $this, 'init_default_settings' ), 'discourse' );
     add_settings_section( 'discourse_comments', 'Comments Settings', array( $this, 'init_comment_settings' ), 'discourse' );
-    add_settings_section( 'discourse_plugin_support', 'Plugin Support', array( $this, 'init_default_settings' ), 'discourse' ); 
+    add_settings_section( 'discourse_plugin_support', 'Plugin Support', array( $this, 'init_default_settings' ), 'discourse' );
     add_settings_section( 'discourse_wp_sso', 'SSO Settings', array( $this, 'init_default_settings' ), 'discourse' );
 
     add_settings_field( 'discourse_url', 'Discourse URL', array( $this, 'url_input' ), 'discourse', 'discourse_wp_api' );
@@ -31,6 +31,7 @@ class DiscourseAdmin {
     add_settings_field( 'discourse_publish_username', 'Publishing username', array( $this, 'publish_username_input' ), 'discourse', 'discourse_wp_api' );
 
     add_settings_field( 'discourse_enable_sso', 'Enable SSO', array( $this, 'enable_sso_checkbox' ), 'discourse', 'discourse_wp_sso' );
+    add_settings_field( 'discourse_wp_login_path', 'Path to your login page', array( $this, 'wordpress_login_path' ), 'discourse', 'discourse_wp_sso' );
     add_settings_field( 'discourse_sso_secret', 'SSO Secret Key', array( $this, 'sso_secret_input' ), 'discourse', 'discourse_wp_sso' );
 
     add_settings_field( 'discourse_publish_category', 'Published category', array( $this, 'publish_category_input' ), 'discourse', 'discourse_wp_publish' );
@@ -40,7 +41,7 @@ class DiscourseAdmin {
     add_settings_field( 'discourse_auto_publish', 'Auto Publish', array( $this, 'auto_publish_checkbox' ), 'discourse', 'discourse_wp_publish' );
     add_settings_field( 'discourse_auto_track', 'Auto Track Published Topics', array( $this, 'auto_track_checkbox' ), 'discourse', 'discourse_wp_publish' );
     add_settings_field( 'discourse_allowed_post_types', 'Post Types to publish to Discourse', array( $this, 'post_types_select' ), 'discourse', 'discourse_wp_publish' );
-    
+
     add_settings_field( 'discourse_woocommerce_support', 'Add WooCommerce support', array( $this, 'woocommerce_support'), 'discourse', 'discourse_plugin_support' );
 
     add_settings_field( 'discourse_use_discourse_comments', 'Use Discourse Comments', array( $this, 'use_discourse_comments_checkbox' ), 'discourse', 'discourse_comments' );
@@ -83,6 +84,10 @@ class DiscourseAdmin {
 
   function url_input() {
     self::text_input( 'url', 'e.g. http://discourse.example.com', 'url' );
+  }
+
+  function wordpress_login_path() {
+    self::text_input( 'login-path', '(Optional) The path to your login page.' );
   }
 
   function api_key_input() {
@@ -177,7 +182,7 @@ class DiscourseAdmin {
   function only_show_moderator_liked_checkbox() {
     self::checkbox_input( 'only-show-moderator-liked', 'Yes' );
   }
-  
+
   function woocommerce_support() {
     self::checkbox_input( 'woocommerce-support', 'Enable support for the Woocommerce plugin' );
   }

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -87,7 +87,7 @@ class DiscourseAdmin {
   }
 
   function wordpress_login_path() {
-    self::text_input( 'login-path', '(Optional) The path to your login page.' );
+    self::text_input( 'login-path', '(Optional) The path to your login page. It should start with \'/\'. Leave blank to use the default WordPress login page.' );
   }
 
   function api_key_input() {

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -69,12 +69,6 @@ class Discourse {
     add_action( 'transition_post_status', array( $this, 'publish_post_to_discourse' ), 10, 3 );
     add_action( 'parse_query', array( $this, 'sso_parse_request' ) );
     add_action( 'admin_enqueue_scripts', array( $this, 'admin_styles' ) );
-
-    if ( self::get_plugin_options()['woocommerce-support'] ) {
-      $woocommerce = Woocommerce\WoocommerceSupport::get_instance();
-      add_filter( $woocommerce->get_comments_number_filter(), array( $this, 'comments_number' ) );
-
-    }
   }
 
   // If a value has been supplied for the 'login-path' option, use it instead of

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -40,7 +40,7 @@ class Discourse {
     'full-post-content' => 0,
     'only-show-moderator-liked' => 0,
     'woocommerce-support' => 0,
-    'login-path' => 'wp-login.php'
+    'login-path' => ''
   );
 
   public function __construct() {

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -37,7 +37,8 @@ class Discourse {
     'bypass-trust-level-score' => 50,
     'debug-mode' => 0,
     'full-post-content' => 0,
-    'only-show-moderator-liked' => 0
+    'only-show-moderator-liked' => 0,
+    'woocommerce-support' => 0
   );
 
   public function __construct() {

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -38,7 +38,6 @@ class Discourse {
     'debug-mode' => 0,
     'full-post-content' => 0,
     'only-show-moderator-liked' => 0,
-    'woocommerce-support' => 0,
     'login-path' => ''
   );
 

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -69,33 +69,35 @@ class Discourse {
     add_action( 'transition_post_status', array( $this, 'publish_post_to_discourse' ), 10, 3 );
     add_action( 'parse_query', array( $this, 'sso_parse_request' ) );
     add_action( 'admin_enqueue_scripts', array( $this, 'admin_styles' ) );
-    
+
     if ( self::get_plugin_options()['woocommerce-support'] ) {
       $woocommerce = Woocommerce\WoocommerceSupport::get_instance();
       add_filter( $woocommerce->get_comments_number_filter(), array( $this, 'comments_number' ) );
-      
+
     }
   }
-  
+
+  // If a value has been supplied for the 'login-path' option, use it instead of
+  // the default WordPress login path.
   function set_login_url( $login_url, $redirect ) {
     $options = self::get_plugin_options();
     if ( $options['login-path'] ) {
       $login_url = $options['login-path'];
-      
+
       if ( !empty( $redirect ) ) {
         return add_query_arg( 'redirect_to', urlencode( $redirect ), $login_url );
-        
+
       } else {
         return $login_url;
       }
     }
-    
+
     if ( !empty( $redirect ) ) {
       return add_query_arg( 'redirect_to', urlencode( $redirect ), $login_url );
     } else {
       return $login_url;
     }
-    
+
   }
 
   function admin_styles() {

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -3,6 +3,7 @@
  * WP-Discourse
  */
 use WPDiscourse\Templates as Templates;
+use WPDiscourse\PluginSupport\WoocommerceSupport as Woocommerce;
 
 class Discourse {
   public static function homepage( $url, $post ) {
@@ -68,6 +69,12 @@ class Discourse {
     add_action( 'transition_post_status', array( $this, 'publish_post_to_discourse' ), 10, 3 );
     add_action( 'parse_query', array( $this, 'sso_parse_request' ) );
     add_action( 'admin_enqueue_scripts', array( $this, 'admin_styles' ) );
+    
+    if ( self::get_plugin_options()['woocommerce-support'] ) {
+      $woocommerce = Woocommerce\WoocommerceSupport::get_instance();
+      add_filter( $woocommerce->get_comments_number_filter(), array( $this, 'comments_number' ) );
+      
+    }
   }
   
   function set_login_url( $login_url, $redirect ) {

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -3,7 +3,6 @@
  * WP-Discourse
  */
 use WPDiscourse\Templates as Templates;
-use WPDiscourse\PluginSupport\WoocommerceSupport as Woocommerce;
 
 class Discourse {
   public static function homepage( $url, $post ) {

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -57,7 +57,7 @@ class Discourse {
 
     // replace comments with discourse comments
     add_filter( 'comments_number', array( $this, 'comments_number' ) );
-    add_filter( 'comments_template', array( $this, 'comments_template' ) );
+    add_filter( 'comments_template', array( $this, 'comments_template' ), 20, 1 );
     add_filter( 'query_vars', array( $this, 'sso_add_query_vars' ) );
     add_filter( 'login_url', array( $this, 'set_login_url' ), 10, 2 );
 

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -38,7 +38,8 @@ class Discourse {
     'debug-mode' => 0,
     'full-post-content' => 0,
     'only-show-moderator-liked' => 0,
-    'woocommerce-support' => 0
+    'woocommerce-support' => 0,
+    'login-path' => 'wp-login.php'
   );
 
   public function __construct() {

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -59,6 +59,7 @@ class Discourse {
     add_filter( 'comments_number', array( $this, 'comments_number' ) );
     add_filter( 'comments_template', array( $this, 'comments_template' ) );
     add_filter( 'query_vars', array( $this, 'sso_add_query_vars' ) );
+    add_filter( 'login_url', array( $this, 'set_login_url' ), 10, 2 );
 
     add_action( 'wp_enqueue_scripts', array( $this, 'discourse_comments_js' ) );
 
@@ -67,6 +68,27 @@ class Discourse {
     add_action( 'transition_post_status', array( $this, 'publish_post_to_discourse' ), 10, 3 );
     add_action( 'parse_query', array( $this, 'sso_parse_request' ) );
     add_action( 'admin_enqueue_scripts', array( $this, 'admin_styles' ) );
+  }
+  
+  function set_login_url( $login_url, $redirect ) {
+    $options = self::get_plugin_options();
+    if ( $options['login-path'] ) {
+      $login_url = $options['login-path'];
+      
+      if ( !empty( $redirect ) ) {
+        return add_query_arg( 'redirect_to', urlencode( $redirect ), $login_url );
+        
+      } else {
+        return $login_url;
+      }
+    }
+    
+    if ( !empty( $redirect ) ) {
+      return add_query_arg( 'redirect_to', urlencode( $redirect ), $login_url );
+    } else {
+      return $login_url;
+    }
+    
   }
 
   function admin_styles() {

--- a/lib/plugin-support/woocommerce_support.php
+++ b/lib/plugin-support/woocommerce_support.php
@@ -14,19 +14,15 @@ class WoocommerceSupport {
   }
 
   private function __construct() {
-    add_action( 'woocommerce_login_form_end', array( $this, 'set_redirect' ) );
+    add_filter( 'woocommerce_login_redirect', array( $this, 'set_redirect' ) );
   }
-
-  // The WooCommerce login form handler (`WC_Form_Handler::process_login`) tries to set the
-  // after-login redirect path based on `$_POST['redirect']`. If that isn't set, it falls back to
-  // the 'myaccount' page permalink. This function sets a hidden 'redirect' field based on the
-  // request's 'redirect_to' value. Doing it this way allows the values for 'sso' and 'sig' to
-  // be passed to the redirect.
-  function set_redirect() {
+  
+  function set_redirect( $redirect ) {
     if ( array_key_exists( 'redirect_to', $_GET ) ) {
       $redirect = $_GET['redirect_to'];
-      echo '<input type="hidden" name="redirect" value="'. $redirect . '">';
+      return $redirect;
     }
+    return $redirect;
   }
 
   function get_comments_number_filter() {

--- a/lib/plugin-support/woocommerce_support.php
+++ b/lib/plugin-support/woocommerce_support.php
@@ -4,26 +4,31 @@ namespace WPDiscourse\PluginSupport\WoocommerceSupport;
 class WoocommerceSupport {
   private static $instance = null;
   protected $comments_number_filter = 'woocommerce_product_review_count';
-  
+
   public static function get_instance() {
     if ( null == self::$instance ) {
       self::$instance = new self;
     }
-    
+
     return self::$instance;
   }
-  
+
   private function __construct() {
     add_action( 'woocommerce_login_form_end', array( $this, 'set_redirect' ) );
   }
-  
+
+  // The WooCommerce login form handler (`WC_Form_Handler::process_login`) tries to set the
+  // after-login redirect path based on `$_POST['redirect']`. If that isn't set, it falls back to
+  // the 'myaccount' page permalink. This function sets a hidden 'redirect' field based on the
+  // request's 'redirect_to' value. Doing it this way allows the values for 'sso' and 'sig' to
+  // be passed to the redirect.
   function set_redirect() {
     if ( array_key_exists( 'redirect_to', $_GET ) ) {
       $redirect = $_GET['redirect_to'];
       echo '<input type="hidden" name="redirect" value="'. $redirect . '">';
     }
   }
-  
+
   function get_comments_number_filter() {
     return $this->comments_number_filter;
   }

--- a/lib/plugin-support/woocommerce_support.php
+++ b/lib/plugin-support/woocommerce_support.php
@@ -1,7 +1,7 @@
 <?php
-namespace WPDiscourse\PluginSupport\WoocommerceSupport;
+namespace WPDiscourse\PluginSupport;
 
-class WoocommerceSupport {
+class WooCommerceSupport {
   private static $instance = null;
   protected $comments_number_filter = 'woocommerce_product_review_count';
 
@@ -15,8 +15,9 @@ class WoocommerceSupport {
 
   private function __construct() {
     add_filter( 'woocommerce_login_redirect', array( $this, 'set_redirect' ) );
+    add_filter( 'woocommerce_product_review_count', array( $this, 'comments_number' ) );
   }
-  
+
   function set_redirect( $redirect ) {
     if ( array_key_exists( 'redirect_to', $_GET ) ) {
       $redirect = $_GET['redirect_to'];
@@ -25,8 +26,9 @@ class WoocommerceSupport {
     return $redirect;
   }
 
-  function get_comments_number_filter() {
-    return $this->comments_number_filter;
+  function comments_number() {
+    global $post;
+    $count = get_post_meta( $post->ID, 'discourse_comments_count', true );
+    return $count ? $count : 0;
   }
-
 }

--- a/lib/plugin-support/woocommerce_support.php
+++ b/lib/plugin-support/woocommerce_support.php
@@ -2,33 +2,22 @@
 namespace WPDiscourse\PluginSupport;
 
 class WooCommerceSupport {
-  private static $instance = null;
-  protected $comments_number_filter = 'woocommerce_product_review_count';
 
-  public static function get_instance() {
-    if ( null == self::$instance ) {
-      self::$instance = new self;
-    }
+  protected $discourse;
 
-    return self::$instance;
-  }
-
-  private function __construct() {
+  function __construct( \Discourse $discourse ) {
+    $this->discourse = $discourse;
     add_filter( 'woocommerce_login_redirect', array( $this, 'set_redirect' ) );
-    add_filter( 'woocommerce_product_review_count', array( $this, 'comments_number' ) );
+    add_filter( 'woocommerce_product_review_count', array( $this->discourse, 'comments_number' ) );
   }
 
   function set_redirect( $redirect ) {
     if ( array_key_exists( 'redirect_to', $_GET ) ) {
       $redirect = $_GET['redirect_to'];
+
       return $redirect;
     }
-    return $redirect;
-  }
 
-  function comments_number() {
-    global $post;
-    $count = get_post_meta( $post->ID, 'discourse_comments_count', true );
-    return $count ? $count : 0;
+    return $redirect;
   }
 }

--- a/lib/plugin-support/woocommerce_support.php
+++ b/lib/plugin-support/woocommerce_support.php
@@ -1,0 +1,31 @@
+<?php
+namespace WPDiscourse\PluginSupport\WoocommerceSupport;
+
+class WoocommerceSupport {
+  private static $instance = null;
+  protected $comments_number_filter = 'woocommerce_product_review_count';
+  
+  public static function get_instance() {
+    if ( null == self::$instance ) {
+      self::$instance = new self;
+    }
+    
+    return self::$instance;
+  }
+  
+  private function __construct() {
+    add_action( 'woocommerce_login_form_end', array( $this, 'set_redirect' ) );
+  }
+  
+  function set_redirect() {
+    if ( array_key_exists( 'redirect_to', $_GET ) ) {
+      $redirect = $_GET['redirect_to'];
+      echo '<input type="hidden" name="redirect" value="'. $redirect . '">';
+    }
+  }
+  
+  function get_comments_number_filter() {
+    return $this->comments_number_filter;
+  }
+
+}

--- a/lib/plugin-support/woocommerce_support.php
+++ b/lib/plugin-support/woocommerce_support.php
@@ -7,6 +7,7 @@ class WooCommerceSupport {
 
   function __construct( \Discourse $discourse ) {
     $this->discourse = $discourse;
+    
     add_filter( 'woocommerce_login_redirect', array( $this, 'set_redirect' ) );
     add_filter( 'woocommerce_product_review_count', array( $this->discourse, 'comments_number' ) );
   }

--- a/lib/plugin-support/woocommerce_support.php
+++ b/lib/plugin-support/woocommerce_support.php
@@ -7,9 +7,18 @@ class WooCommerceSupport {
 
   function __construct( \Discourse $discourse ) {
     $this->discourse = $discourse;
-    
+
     add_filter( 'woocommerce_login_redirect', array( $this, 'set_redirect' ) );
-    add_filter( 'woocommerce_product_review_count', array( $this->discourse, 'comments_number' ) );
+    add_action( 'init', array( $this, 'set_product_review_count_filter' ) );
+  }
+
+  // Only use the Discourse comments number if 'product' is in allowed post types.
+  function set_product_review_count_filter() {
+    $options = get_option('discourse');
+    if ( array_key_exists( 'allowed_post_types', $options ) 
+         && in_array( 'product', $options['allowed_post_types'] ) ) {
+      add_filter( 'woocommerce_product_review_count', array( $this->discourse, 'comments_number' ) );
+    }
   }
 
   function set_redirect( $redirect ) {

--- a/lib/settings-validator.php
+++ b/lib/settings-validator.php
@@ -298,8 +298,10 @@ class SettingsValidator {
         return $this->sanitize_text( $input );
         
       }
+      // It's valid
       return $this->sanitize_text( $input );
     }
+    // Sanitize, but don't validate. SSO is not enabled.
     return $this->sanitize_text( $input );
   }
 

--- a/lib/settings-validator.php
+++ b/lib/settings-validator.php
@@ -105,7 +105,6 @@ class SettingsValidator {
     add_filter( 'validate_debug_mode', array( $this, 'validate_debug_mode' ) );
     add_filter( 'validate_enable_sso', array( $this, 'validate_enable_sso' ) );
     add_filter( 'validate_sso_secret', array( $this, 'validate_sso_secret' ) );
-    add_filter( 'validate_woocommerce_support', array( $this, 'validate_woocommerce_support' ) );
     add_filter( 'validate_login_path', array( $this, 'validate_login_path' ) );
   }
 
@@ -283,10 +282,6 @@ class SettingsValidator {
     } else {
       return sanitize_text_field( $input );
     }
-  }
-
-  public function validate_woocommerce_support( $input ) {
-    return $this->sanitize_checkbox( $input );
   }
 
   public function validate_login_path( $input ) {

--- a/lib/settings-validator.php
+++ b/lib/settings-validator.php
@@ -105,6 +105,8 @@ class SettingsValidator {
     add_filter( 'validate_debug_mode', array( $this, 'validate_debug_mode' ) );
     add_filter( 'validate_enable_sso', array( $this, 'validate_enable_sso' ) );
     add_filter( 'validate_sso_secret', array( $this, 'validate_sso_secret' ) );
+    add_filter( 'validate_woocommerce_support', array( $this, 'validate_woocommerce_support' ) );
+    add_filter( 'validate_login_path', array( $this, 'validate_login_path' ) );
   }
 
   public function validate_url( $input ) {
@@ -281,6 +283,22 @@ class SettingsValidator {
     } else {
       return sanitize_text_field( $input );
     }
+  }
+
+  public function validate_woocommerce_support( $input ) {
+    return $this->sanitize_checkbox( $input );
+  }
+
+  public function validate_login_path( $input ) {
+    if ( $this->sso_enabled && $input ) {
+      $regex = '/$(\/[a-z0-9\-]*)*/';
+      if ( ! preg_match( $regex, $input ) ) {
+        add_settings_error( 'discourse', 'login_path', __( 'You have given an invalid file path', 'wp-discourse' ) );
+        return $this->sanitize_text( $input );
+      }
+      return $this->sanitize_text( $input );
+    }
+    return $this->sanitize_text( $input );
   }
 
   // Helper methods

--- a/lib/settings-validator.php
+++ b/lib/settings-validator.php
@@ -291,7 +291,8 @@ class SettingsValidator {
 
   public function validate_login_path( $input ) {
     if ( $this->sso_enabled && $input ) {
-      $regex = '/$(\/[a-z0-9\-]*)*/';
+      // todo: improve regex
+      $regex = '/^\/([a-z0-9\-]*)*/';
       if ( ! preg_match( $regex, $input ) ) {
         add_settings_error( 'discourse', 'login_path', __( 'You have given an invalid file path', 'wp-discourse' ) );
         return $this->sanitize_text( $input );

--- a/lib/settings-validator.php
+++ b/lib/settings-validator.php
@@ -291,11 +291,12 @@ class SettingsValidator {
 
   public function validate_login_path( $input ) {
     if ( $this->sso_enabled && $input ) {
-      // todo: improve regex
-      $regex = '/^\/([a-z0-9\-]*)*/';
+      
+      $regex = '/^\/([a-z0-9\-]+)(\/[a-z0-9\-]+)*(\/)?$/';
       if ( ! preg_match( $regex, $input ) ) {
-        add_settings_error( 'discourse', 'login_path', __( 'You have given an invalid file path', 'wp-discourse' ) );
+        add_settings_error( 'discourse', 'login_path', __( 'The path to login page setting needs to be a valid file path, starting with \'/\'.', 'wp-discourse' ) );
         return $this->sanitize_text( $input );
+        
       }
       return $this->sanitize_text( $input );
     }

--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -42,6 +42,6 @@ require_once( __DIR__ . '/lib/plugin-support/woocommerce_support.php' );
 $discourse = new Discourse();
 $discourse_settings_validator = new WPDiscourse\Validator\SettingsValidator();
 $discourse_admin = new DiscourseAdmin();
-$woocommerce_support = WPDiscourse\PluginSupport\WooCommerceSupport::get_instance();
+$woocommerce_support = new WPDiscourse\PluginSupport\WooCommerceSupport( $discourse );
 
 register_activation_hook( __FILE__, array( $discourse, 'install' ) );

--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -42,5 +42,6 @@ require_once( __DIR__ . '/lib/plugin-support/woocommerce_support.php' );
 $discourse = new Discourse();
 $discourse_settings_validator = new WPDiscourse\Validator\SettingsValidator();
 $discourse_admin = new DiscourseAdmin();
+$woocommerce_support = WPDiscourse\PluginSupport\WooCommerceSupport::get_instance();
 
 register_activation_hook( __FILE__, array( $discourse, 'install' ) );

--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -37,6 +37,7 @@ require_once( __DIR__ . '/lib/discourse.php' );
 require_once( __DIR__ . '/lib/settings-validator.php' );
 require_once( __DIR__ . '/lib/admin.php' );
 require_once( __DIR__ . '/lib/sso.php' );
+require_once( __DIR__ . '/lib/plugin-support/woocommerce_support.php' );
 
 $discourse = new Discourse();
 $discourse_settings_validator = new WPDiscourse\Validator\SettingsValidator();


### PR DESCRIPTION
Allows Discourse to be used for WooCommerce product reviews.

- ~~Adds a 'plugin support' section to the settings page, with an 'Enable WooCommerce Support' setting~~
- Adds a 'login-path' setting to the settings page SSO section. This makes it possible to override the default WordPress login page. To use the WooCommerce 'my-account' page for login, the login path should be set to '/my-account'
- Increases the priority of the Discourse comments template so that it will be used in place of the comments template that is set through WooCommerce or other plugins
- Adds a `WoocommerceSupport` class that sets the proper redirect from WordPress to Discourse when the WooCommerce `/my-account` page is used as the login page. ~~It also returns the name of the WooCommerce comments_number_filter, and hooks it  into the `Discouse::comments_number` method.~~

If the 'login-path' setting is not set, the default WordPress login page `wp-login.php` will be used. Setting the 'login-path' makes it possible to use any page on the WordPress site as the login page. An example of how to do this can be added to the documentation.

Does this feature belong in the plugin? Most of these changes could also be made in the theme's `functions.php` file.

see:
https://github.com/discourse/wp-discourse/issues/173

https://meta.discourse.org/t/wp-discourse-sso-plugin/23245/40?u=simon_cossar
