### PR TITLE
Change min-replies default to 1

### DIFF
--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -31,7 +31,7 @@ class Discourse {
     'use-discourse-comments' => 0,
     'show-existing-comments' => 0,
     'min-score' => 30,
-    'min-replies' => 5,
+    'min-replies' => 1,
     'min-trust-level' => 1,
     'custom-excerpt-length' => 55,
     'bypass-trust-level-score' => 50,


### PR DESCRIPTION
The 'Min number of replies' setting has confused a few users (including me.) This PR sets the default value for the 'Min number of replies' setting to 1.

See https://meta.discourse.org/t/comments-not-being-embedded-in-wordpress-plugin/40345/12?u=simon_cossar and
https://meta.discourse.org/t/discourse-wordpress-plugin-version-0-6-6/31585/27?u=simon_cossar