### PR TITLE
Updated to valid JSON formatting

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,6 +1,6 @@
 {
-  "userBlacklist": [
-    'tnorthcutt',
-    'retlehs'
-    ]
+	"userBlacklist": [
+		"tnorthcutt",
+		"retlehs"
+	]
 }


### PR DESCRIPTION
JSON only supports double quotes for strings.

Sorry about the bot bothering you again @retlehs and @tnorthcutt. This *should* fix it.