### PR TITLE
FIX: Escape existing comments heading

### DIFF
--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -309,7 +309,7 @@ class Discourse {
       } else {
         // show the Discourse comments then show the existing WP comments (in $old)
         include WPDISCOURSE_PATH . '/templates/comments.php';
-        echo '<div class="discourse-existing-comments-heading">' . $options['existing-comments-heading'] . '</div>';
+        echo '<div class="discourse-existing-comments-heading">' . esc_html( $options['existing-comments-heading'] ) . '</div>';
         return $old;
       }
     }

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -309,7 +309,7 @@ class Discourse {
       } else {
         // show the Discourse comments then show the existing WP comments (in $old)
         include WPDISCOURSE_PATH . '/templates/comments.php';
-        echo '<div class="discourse-existing-comments-heading">' . esc_html( $options['existing-comments-heading'] ) . '</div>';
+        echo '<div class="discourse-existing-comments-heading">' . wp_kses_post( $options['existing-comments-heading'] ) . '</div>';
         return $old;
       }
     }


### PR DESCRIPTION
Sanitize the 'existing comments heading' with `wp_kses_post`.