### PR TITLE
Improve login path validation

### DIFF
--- a/lib/settings-validator.php
+++ b/lib/settings-validator.php
@@ -287,7 +287,7 @@ class SettingsValidator {
   public function validate_login_path( $input ) {
     if ( $this->sso_enabled && $input ) {
       
-      $regex = '/^\/([a-z0-9\-]+)(\/[a-z0-9\-]+)*(\/)?$/';
+      $regex = '/^\/([a-z0-9\-]+)*(\/[a-z0-9\-]+)*(\/)?$/';
       if ( ! preg_match( $regex, $input ) ) {
         add_settings_error( 'discourse', 'login_path', __( 'The path to login page setting needs to be a valid file path, starting with \'/\'.', 'wp-discourse' ) );
         return $this->sanitize_text( $input );


### PR DESCRIPTION
This could be improved. This change allows `/` as a valid path.