### PR TITLE
FEATURE: use WordPress excerpt if there is one

### DIFF
--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -445,14 +445,19 @@ class Discourse {
     $use_full_post = isset( $options['full-post-content'] ) && intval( $options['full-post-content'] ) == 1;
 
     if ($use_full_post) {
-      $excerpt = $raw;
+      $excerpt = apply_filters( 'wp_discourse_excerpt', $raw );
     } else {
-      $excerpt = apply_filters( 'the_content', $raw );
-      $excerpt = wp_trim_words( $excerpt, $options['custom-excerpt-length'] );
+      if ( has_excerpt( $postid ) ) {
+        // This works since WordPress 4.5.0
+        $excerpt = apply_filters( 'wp_discourse_excerpt', get_the_excerpt( $postid ) );
+      } else {
+        $excerpt = apply_filters( 'the_content', $raw );
+        $excerpt = apply_filters( 'wp_discourse_excerpt',  wp_trim_words( $excerpt, $options['custom-excerpt-length'] ) );
+      }
     }
 
     if ( function_exists( 'discourse_custom_excerpt' ) ) {
-      $excerpt = discourse_custom_excerpt( $postid );
+      $excerpt = apply_filters( 'wp_discourse_excerpt', discourse_custom_excerpt( $postid ) );
     }
 
     // trim to keep the Discourse markdown parser from treating this as code.

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -456,10 +456,6 @@ class Discourse {
       }
     }
 
-//    if ( function_exists( 'discourse_custom_excerpt' ) ) {
-//      $excerpt = apply_filters( 'wp_discourse_excerpt', discourse_custom_excerpt( $postid ) );
-//    }
-
     // trim to keep the Discourse markdown parser from treating this as code.
     $baked = trim( Templates\HTMLTemplates::publish_format_html() );
     $baked = str_replace( "{excerpt}", $excerpt, $baked );

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -448,17 +448,17 @@ class Discourse {
       $excerpt = apply_filters( 'wp_discourse_excerpt', $raw );
     } else {
       if ( has_excerpt( $postid ) ) {
-        // This works since WordPress 4.5.0
-        $excerpt = apply_filters( 'wp_discourse_excerpt', get_the_excerpt( $postid ) );
+        $wp_excerpt = apply_filters( 'get_the_excerpt', $post->post_excerpt );
+        $excerpt = apply_filters( 'wp_discourse_excerpt', $wp_excerpt );
       } else {
         $excerpt = apply_filters( 'the_content', $raw );
         $excerpt = apply_filters( 'wp_discourse_excerpt',  wp_trim_words( $excerpt, $options['custom-excerpt-length'] ) );
       }
     }
 
-    if ( function_exists( 'discourse_custom_excerpt' ) ) {
-      $excerpt = apply_filters( 'wp_discourse_excerpt', discourse_custom_excerpt( $postid ) );
-    }
+//    if ( function_exists( 'discourse_custom_excerpt' ) ) {
+//      $excerpt = apply_filters( 'wp_discourse_excerpt', discourse_custom_excerpt( $postid ) );
+//    }
 
     // trim to keep the Discourse markdown parser from treating this as code.
     $baked = trim( Templates\HTMLTemplates::publish_format_html() );


### PR DESCRIPTION
If `Use full post content` is **not** selected, this PR checks to see if a manual excerpt has been set for the post. If it has, it is used instead of the excerpt that is generated by the plugin.

This PR also applies a `wp_discourse_excerpt` filter to the excerpt so that it can be customized in the theme.