### PR TITLE
[WIP]: Handle bad response from Discourse

### DIFF
--- a/css/wp-discourse-styles.css
+++ b/css/wp-discourse-styles.css
@@ -1,9 +1,0 @@
-/* The notice for when there is a bad connection with Discourse. */
-.no-connection-notice {
-    font-size: 14px;
-    border: 1px solid #ebccd1;
-    color: #a94442;
-    background: #f2dede;
-    border-radius: 4px;
-    padding: 15px;
-}

--- a/css/wp-discourse-styles.css
+++ b/css/wp-discourse-styles.css
@@ -1,0 +1,9 @@
+/* The notice for when there is a bad connection with Discourse. */
+.no-connection-notice {
+    font-size: 14px;
+    border: 1px solid #ebccd1;
+    color: #a94442;
+    background: #f2dede;
+    border-radius: 4px;
+    padding: 15px;
+}

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -11,10 +11,8 @@ class DiscourseAdmin {
    * Discourse constructor.
    *
    * Takes a `response_validator` object as a parameter.
-   * The `response_validator` has a `validate()` method that validates the response
-   * from `wp_remote_get` and `wp_remote_post`.
-   * It also has a `check_connection_status` method that may be run to periodically check
-   * the connection status to Discourse.
+   * It has a `check_connection_status` method that may be run to check
+   * the site's connection status to Discourse.
    *
    * @param $response_validator
    */

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -424,7 +424,7 @@ class DiscourseAdmin {
   }
 
   function connection_status_notice() {
-    if ( ! $this->test_api_credentials() ) {
+    if ( ! $this->response_validator->check_connection_status() ) {
       add_action( 'admin_notices' , array( $this, 'disconnected' ) );
     } else {
       add_action( 'admin_notices', array($this, 'connected' ) );
@@ -451,23 +451,6 @@ class DiscourseAdmin {
       </p>
     </div>
     <?php
-  }
-
-  protected function test_api_credentials() {
-    $options = $this->options;
-    $url = array_key_exists( 'url', $options ) ? $options['url'] . '/categories.json' : '';
-
-    $url = add_query_arg( array(
-      "api_key" => array_key_exists( 'api-key', $options  ) ? $options['api-key'] : '' ,
-      "api_username" => array_key_exists( 'publish-username', $options ) ? $options['publish-username'] : ''
-    ), $url );
-    $response = wp_remote_get( $url );
-    $invalid_response = wp_remote_retrieve_response_code( $response ) != 200;
-
-    if ( is_wp_error( $response ) || $invalid_response ) {
-      return false;
-    }
-    return true;
   }
 
   protected function post_types_to_publish( $excluded_types = array() ) {

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -5,8 +5,21 @@
 
 class DiscourseAdmin {
   protected $options;
+  protected $response_validator;
 
-  public function __construct() {
+  /**
+   * Discourse constructor.
+   *
+   * Takes a `response_validator` object as a parameter.
+   * The `response_validator` has a `validate()` method that validates the response
+   * from `wp_remote_get` and `wp_remote_post`.
+   * It also has a `check_connection_status` method that may be run to periodically check
+   * the connection status to Discourse.
+   *
+   * @param $response_validator
+   */
+  public function __construct( $response_validator ) {
+    $this->response_validator = $response_validator;
     $this->options = get_option( 'discourse' );
 
     add_action( 'admin_init', array( $this, 'admin_init' ) );

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -49,8 +49,6 @@ class Discourse {
    * Takes a `response_validator` object as a parameter.
    * The `response_validator` has a `validate()` method that validates the response
    * from `wp_remote_get` and `wp_remote_post`.
-   * It also has a `check_connection_status` method that may be run to periodically check
-   * the connection status to Discourse.
    *
    * @param $response_validator
    */

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -45,7 +45,7 @@ class Discourse {
 
   /**
    * Discourse constructor.
-   * 
+   *
    * Takes a `response_validator` object as a parameter.
    * The `response_validator` has a `validate()` method that validates the response
    * from `wp_remote_get` and `wp_remote_post`.
@@ -82,6 +82,7 @@ class Discourse {
     add_action( 'transition_post_status', array( $this, 'publish_post_to_discourse' ), 10, 3 );
     add_action( 'parse_query', array( $this, 'sso_parse_request' ) );
     add_action( 'admin_enqueue_scripts', array( $this, 'admin_styles' ) );
+    add_action( 'wp_enqueue_scripts', array( $this, 'plugin_styles' ) );
   }
 
   // If a value has been supplied for the 'login-path' option, use it instead of
@@ -110,6 +111,11 @@ class Discourse {
   function admin_styles() {
     wp_register_style( 'wp_discourse_admin', WPDISCOURSE_URL . '/css/admin-styles.css' );
     wp_enqueue_style( 'wp_discourse_admin' );
+  }
+
+  function plugin_styles() {
+    wp_register_style( 'wp_discourse_styles', WPDISCOURSE_URL . '/css/wp-discourse-styles.css' );
+    wp_enqueue_style( 'wp_discourse_styles' );
   }
 
   function discourse_comments_js() {
@@ -535,6 +541,7 @@ class Discourse {
           add_post_meta( $postid, 'discourse_post_id', $discourse_id, true );
         }
       }
+
     } else {
       $data = array(
           'api_key' => $options['api-key'],

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -45,7 +45,7 @@ class Discourse {
 
   /**
    * Discourse constructor.
-   *
+   * 
    * Takes a `response_validator` object as a parameter.
    * The `response_validator` has a `validate()` method that validates the response
    * from `wp_remote_get` and `wp_remote_post`.
@@ -82,7 +82,6 @@ class Discourse {
     add_action( 'transition_post_status', array( $this, 'publish_post_to_discourse' ), 10, 3 );
     add_action( 'parse_query', array( $this, 'sso_parse_request' ) );
     add_action( 'admin_enqueue_scripts', array( $this, 'admin_styles' ) );
-    add_action( 'wp_enqueue_scripts', array( $this, 'plugin_styles' ) );
   }
 
   // If a value has been supplied for the 'login-path' option, use it instead of
@@ -111,11 +110,6 @@ class Discourse {
   function admin_styles() {
     wp_register_style( 'wp_discourse_admin', WPDISCOURSE_URL . '/css/admin-styles.css' );
     wp_enqueue_style( 'wp_discourse_admin' );
-  }
-
-  function plugin_styles() {
-    wp_register_style( 'wp_discourse_styles', WPDISCOURSE_URL . '/css/wp-discourse-styles.css' );
-    wp_enqueue_style( 'wp_discourse_styles' );
   }
 
   function discourse_comments_js() {
@@ -541,7 +535,6 @@ class Discourse {
           add_post_meta( $postid, 'discourse_post_id', $discourse_id, true );
         }
       }
-
     } else {
       $data = array(
           'api_key' => $options['api-key'],

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -332,8 +332,6 @@ class Discourse {
         }
         $wpdb->get_results( "SELECT RELEASE_LOCK( 'discourse_lock' )" );
       }
-    } else {
-      $this->response_validator->check_connection_status( 60 );
     }
   }
 

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -6,7 +6,7 @@ use WPDiscourse\Templates as Templates;
 
 class Discourse {
   protected $response_validator;
-  
+
   public static function homepage( $url, $post ) {
     return $url . "/users/" . strtolower( $post->username );
   }
@@ -56,7 +56,7 @@ class Discourse {
    */
   public function __construct( $response_validator ) {
     $this->response_validator = $response_validator;
-    
+
     add_action( 'init', array( $this, 'init' ) );
   }
 
@@ -306,11 +306,11 @@ class Discourse {
           }
           $options = $options . '&api_key=' . $discourse_options['api-key'] . '&api_username=' . $discourse_options['publish-username'];
 
-          $permalink = (string) get_post_meta( $postid, 'discourse_permalink', true ) . '/wordpress.json?' . $options;
+          $permalink = esc_url_raw( get_post_meta( $postid, 'discourse_permalink', true ) ) . '/wordpress.json?' . $options;
           $result = wp_remote_get( $permalink );
-          if ( is_wp_error( $result ) ) {
-             error_log( $result->get_error_message() );
-          } else {
+
+          if ( $this->response_validator->validate( $result ) ) {
+
             $json = json_decode( $result['body'] );
 
             if ( isset( $json->posts_count ) ) {
@@ -323,7 +323,6 @@ class Discourse {
               add_post_meta( $postid, 'discourse_comments_count', $posts_count, true );
 
               delete_post_meta( $postid, 'discourse_comments_raw' );
-
               add_post_meta( $postid, 'discourse_comments_raw', esc_sql( $result['body'] ) , true );
 
               delete_post_meta( $postid, 'discourse_last_sync' );
@@ -333,6 +332,8 @@ class Discourse {
         }
         $wpdb->get_results( "SELECT RELEASE_LOCK( 'discourse_lock' )" );
       }
+    } else {
+      $this->response_validator->check_connection_status( 60 );
     }
   }
 
@@ -436,7 +437,6 @@ class Discourse {
       add_post_meta( $_POST['ID'], 'publish_post_category',  $_POST['publish_post_category'], true );
     }
 
-
     add_post_meta( $_POST['ID'], 'publish_to_discourse', self::publish_active() ? '1' : '0', true );
 
     return $postid;
@@ -524,12 +524,8 @@ class Discourse {
       );
       $result = wp_remote_post( $url, $post_options);
 
-      if ( is_wp_error( $result ) ) {
-        error_log( $result->get_error_message() );
-      } else {
+      if ( $this->response_validator->validate( $result ) ) {
         $json = json_decode( $result['body'] );
-
-        // todo may have $json->errors with list of errors
 
         if( property_exists( $json, 'id' ) ) {
           $discourse_id = (int) $json->id;
@@ -554,12 +550,8 @@ class Discourse {
       );
       $result = wp_remote_post( $url, $post_options);
 
-      if ( is_wp_error( $result ) ) {
-        error_log( $result->get_error_message() );
-      } else {
+      if ( $this->response_validator->validate( $result ) ) {
         $json = json_decode( $result['body'] );
-
-        // todo may have $json->errors with list of errors
 
         if( property_exists( $json, 'id' ) ) {
           $discourse_id = (int) $json->id;

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -5,6 +5,8 @@
 use WPDiscourse\Templates as Templates;
 
 class Discourse {
+  protected $response_validator;
+  
   public static function homepage( $url, $post ) {
     return $url . "/users/" . strtolower( $post->username );
   }
@@ -41,7 +43,20 @@ class Discourse {
     'login-path' => ''
   );
 
-  public function __construct() {
+  /**
+   * Discourse constructor.
+   * 
+   * Takes a `response_validator` object as a parameter.
+   * The `response_validator` has a `validate()` method that validates the response
+   * from `wp_remote_get` and `wp_remote_post`.
+   * It also has a `check_connection_status` method that may be run to periodically check
+   * the connection status to Discourse.
+   *
+   * @param $response_validator
+   */
+  public function __construct( $response_validator ) {
+    $this->response_validator = $response_validator;
+    
     add_action( 'init', array( $this, 'init' ) );
   }
 

--- a/lib/html-templates.php
+++ b/lib/html-templates.php
@@ -14,8 +14,6 @@ class HTMLTemplates {
   /**
    * HTML template for replies.
    *
-   * Checks the connection before displaying the 'Continue the discussion' link.
-   *
    * Can be customized from within a theme using the filter provided.
    *
    * Available tags:
@@ -24,50 +22,31 @@ class HTMLTemplates {
    *
    * @static
    *
-   * @param $connection_status
-   *
    * @return mixed|void
    */
-  public static function replies_html( $connection ) {
+  public static function replies_html() {
     ob_start();
     ?>
     <div id="comments" class="comments-area">
-      <h2
-        class="comments-title"><?php _e( 'Notable Replies', 'wp-discourse' ); ?></h2>
+      <h2 class="comments-title"><?php _e( 'Notable Replies', 'wp-discourse' ); ?></h2>
       <ol class="comment-list">{comments}</ol>
       <div class="respond comment-respond">
-
-        <?php if ( $connection ) : ?>
-          <h3 id="reply-title" class="comment-reply-title">
-            <a href="{topic_url}">
-              <?php _e( 'Continue the discussion', 'wp-discourse' ); ?>
-            </a> <?php _e( ' at ', 'wp-discourse' ); ?>{discourse_url_name}
-          </h3>
-          <p class="more-replies">{more_replies}</p>
-        <?php else : ?>
-          <h3 id="reply-title" class="comment-reply-title">
-            <?php _e( 'Continue the discussion...', 'wp-discourse' ); ?>
-          </h3>
-          <p id="reply-title" class="comment-reply-title no-connection-notice">
-            <?php _e( 'We are currently not able to connect to our forum. ' .
-                      'The site administrator has been notified, Please try again soon.', 'wp-discourse' ); ?>
-          </p>
-
-        <?php endif; ?>
-
+        <h3 id="reply-title" class="comment-reply-title">
+          <a href="{topic_url}"><?php _e( 'Continue the discussion', 'wp-discourse' ); ?>
+          </a><?php _e( ' at ', 'wp-discourse' ); ?>{discourse_url_name}
+        </h3>
+        <p class="more-replies">{more_replies}</p>
         <p class="comment-reply-title">{participants}</p>
       </div><!-- #respond -->
     </div>
     <?php
     $output = ob_get_clean();
 
-    return apply_filters( 'discourse_replies_html', $output, $connection );
+    return apply_filters( 'discourse_replies_html', $output );
   }
 
   /**
    * HTML template for no replies.
-   *
-   * Checks the connection status before displaying the 'Start the discussion' link.
    *
    * Can be customized from within a theme using the filter provided.
    *
@@ -77,34 +56,20 @@ class HTMLTemplates {
    * @static
    * @return mixed|void
    */
-  public static function no_replies_html( $connection ) {
+  public static function no_replies_html() {
     ob_start();
     ?>
     <div id="comments" class="comments-area">
       <div class="respond comment-respond">
-
-        <?php if ( $connection ) : ?>
-          <h3 id="reply-title" class="comment-reply-title"><a
-              href="{topic_url}">
-              <?php _e( 'Start the discussion', 'wp-discourse' ); ?>
-            </a><?php _e( ' at ', 'wp-discourse' ); ?>{discourse_url_name}
-          </h3>
-        <?php else : ?>
-          <h3 id="reply-title" class="comment-reply-title">
-            <?php _e( 'Start the discussion...', 'wp-discourse' ); ?>
-          </h3>
-          <p id="reply-title" class="comment-reply-title no-connection-notice">
-            <?php _e( 'We are currently unable to connect with our forum. ' .
-                      'The site administrator has been notified. Please try again soon.', 'wp-discourse' ); ?>
-          </p>
-        <?php endif; ?>
-
+        <h3 id="reply-title" class="comment-reply-title"><a href="{topic_url}">
+            <?php _e( 'Start the discussion', 'wp-discourse' ); ?>
+          </a><?php _e( ' at ', 'wp-discourse' ); ?>{discourse_url_name}</h3>
       </div><!-- #respond -->
     </div>
     <?php
     $output = ob_get_clean();
 
-    return apply_filters( 'discourse_no_replies_html', $output, $connection );
+    return apply_filters( 'discourse_no_replies_html', $output );
   }
 
   /**
@@ -121,12 +86,10 @@ class HTMLTemplates {
     ob_start();
     ?>
     <div class="respond comment-respond">
-      <h3 id="reply-title" class="comment-reply-title">
-        <?php _e( 'Start the discussion...', 'wp-discourse' ); ?>
-      </h3>
-      <div class="comment-reply-title no-connection-notice">
-        <p><?php _e( 'We are currently unable to connect with the Discourse forum. ' .
-                     'The site administrator has been notified. Please try again later.', 'wp-discourse' ); ?></p>
+      <div class="comment-reply-title discourse-connection-notice">
+        <p><?php _e( 'We are unable to connect this post with the Discourse forum. ' .
+                     'The site administrator has been notified. Please try again later.', 'wp-discourse' ); ?>
+        </p>
       </div>
     </div>
     <?php
@@ -155,7 +118,8 @@ class HTMLTemplates {
       <article class="comment-body">
         <footer class="comment-meta">
           <div class="comment-author vcard">
-            <img alt="" src="{avatar_url}" class="avatar avatar-64 photo avatar-default" height="64" width="64">
+            <img alt="" src="{avatar_url}" class="avatar avatar-64 photo avatar-default" height="64"
+                 width="64">
             <b class="fn"><a href="{topic_url}" rel="external" class="url">{fullname}</a></b>
             <span class="says">says:</span>
           </div>
@@ -192,7 +156,8 @@ class HTMLTemplates {
   public static function participant_html() {
     ob_start();
     ?>
-    <img alt="" src="{avatar_url}" class="avatar avatar-25 photo avatar-default" height="25" width="25">
+    <img alt="" src="{avatar_url}" class="avatar avatar-25 photo avatar-default" height="25"
+         width="25">
     <?php
     $output = ob_get_clean();
 

--- a/lib/html-templates.php
+++ b/lib/html-templates.php
@@ -86,9 +86,8 @@ class HTMLTemplates {
     ob_start();
     ?>
     <div class="respond comment-respond">
-      <div class="comment-reply-title discourse-connection-notice">
-        <p><?php _e( 'We are unable to connect this post with the Discourse forum. ' .
-                     'The site administrator has been notified. Please try again later.', 'wp-discourse' ); ?>
+      <div class="comment-reply-title discourse-no-connection-notice">
+        <p><?php _e( 'Comments are not enabled for this post.', 'wp-discourse' ); ?>
         </p>
       </div>
     </div>

--- a/lib/html-templates.php
+++ b/lib/html-templates.php
@@ -12,7 +12,9 @@ namespace WPDiscourse\Templates;
 class HTMLTemplates {
 
   /**
-   * HTML template for replies
+   * HTML template for replies.
+   *
+   * Checks the connection before displaying the 'Continue the discussion' link.
    *
    * Can be customized from within a theme using the filter provided.
    *
@@ -21,30 +23,51 @@ class HTMLTemplates {
    * {topic_url}, {more_replies}, {participants}
    *
    * @static
+   *
+   * @param $connection_status
+   *
    * @return mixed|void
    */
-  public static function replies_html() {
+  public static function replies_html( $connection ) {
     ob_start();
     ?>
     <div id="comments" class="comments-area">
-      <h2 class="comments-title"><?php _e( 'Notable Replies', 'wp-discourse' ); ?></h2>
+      <h2
+        class="comments-title"><?php _e( 'Notable Replies', 'wp-discourse' ); ?></h2>
       <ol class="comment-list">{comments}</ol>
       <div class="respond comment-respond">
-        <h3 id="reply-title" class="comment-reply-title">
-          <a href="{topic_url}"><?php _e( 'Continue the discussion', 'wp-discourse' ); ?>
-          </a><?php _e( ' at ', 'wp-discourse' ); ?>{discourse_url_name}
-        </h3>
-        <p class="more-replies">{more_replies}</p>
+
+        <?php if ( $connection ) : ?>
+          <h3 id="reply-title" class="comment-reply-title">
+            <a href="{topic_url}">
+              <?php _e( 'Continue the discussion', 'wp-discourse' ); ?>
+            </a> <?php _e( ' at ', 'wp-discourse' ); ?>{discourse_url_name}
+          </h3>
+          <p class="more-replies">{more_replies}</p>
+        <?php else : ?>
+          <h3 id="reply-title" class="comment-reply-title">
+            <?php _e( 'Continue the discussion...', 'wp-discourse' ); ?>
+          </h3>
+          <p id="reply-title" class="comment-reply-title no-connection-notice">
+            <?php _e( 'We are currently not able to connect to our forum. ' .
+                      'The site administrator has been notified, Please try again soon.', 'wp-discourse' ); ?>
+          </p>
+
+        <?php endif; ?>
+
         <p class="comment-reply-title">{participants}</p>
       </div><!-- #respond -->
     </div>
     <?php
     $output = ob_get_clean();
-    return apply_filters( 'discourse_replies_html', $output );
+
+    return apply_filters( 'discourse_replies_html', $output, $connection );
   }
 
   /**
-   * HTML template for no replies
+   * HTML template for no replies.
+   *
+   * Checks the connection status before displaying the 'Start the discussion' link.
    *
    * Can be customized from within a theme using the filter provided.
    *
@@ -54,19 +77,34 @@ class HTMLTemplates {
    * @static
    * @return mixed|void
    */
-  public static function no_replies_html() {
+  public static function no_replies_html( $connection ) {
     ob_start();
     ?>
     <div id="comments" class="comments-area">
       <div class="respond comment-respond">
-        <h3 id="reply-title" class="comment-reply-title"><a href="{topic_url}">
-            <?php _e( 'Start the discussion', 'wp-discourse' ); ?>
-          </a><?php _e( ' at ', 'wp-discourse' ); ?>{discourse_url_name}</h3>
+
+        <?php if ( $connection ) : ?>
+          <h3 id="reply-title" class="comment-reply-title"><a
+              href="{topic_url}">
+              <?php _e( 'Start the discussion', 'wp-discourse' ); ?>
+            </a><?php _e( ' at ', 'wp-discourse' ); ?>{discourse_url_name}
+          </h3>
+        <?php else : ?>
+          <h3 id="reply-title" class="comment-reply-title">
+            <?php _e( 'Start the discussion...', 'wp-discourse' ); ?>
+          </h3>
+          <p id="reply-title" class="comment-reply-title no-connection-notice">
+            <?php _e( 'We are currently unable to connect with our forum. ' .
+                      'The site administrator has been notified. Please try again soon.', 'wp-discourse' ); ?>
+          </p>
+        <?php endif; ?>
+
       </div><!-- #respond -->
     </div>
     <?php
     $output = ob_get_clean();
-    return apply_filters( 'discourse_no_replies_html', $output );
+
+    return apply_filters( 'discourse_no_replies_html', $output, $connection );
   }
 
   /**
@@ -74,7 +112,7 @@ class HTMLTemplates {
    * with bad credentials.
    * This template is displayed in the comments section when there is no `discourse_permalink`
    * index in the response returned from `Discourse::sync_to_discourse_work`
-   * 
+   *
    * Can be customized in the theme using the filter provided.
    *
    * @return mixed|void
@@ -135,6 +173,7 @@ class HTMLTemplates {
     </li>
     <?php
     $output = ob_get_clean();
+
     return apply_filters( 'discourse_comment_html', $output );
   }
 
@@ -156,6 +195,7 @@ class HTMLTemplates {
     <img alt="" src="{avatar_url}" class="avatar avatar-25 photo avatar-default" height="25" width="25">
     <?php
     $output = ob_get_clean();
+
     return apply_filters( 'discourse_participant_html', $output );
   }
 
@@ -176,6 +216,7 @@ class HTMLTemplates {
     <small>Originally published at: {blogurl}</small><br>{excerpt}
     <?php
     $output = ob_get_clean();
+
     return apply_filters( 'discourse_publish_format_html', $output );
   }
 }

--- a/lib/html-templates.php
+++ b/lib/html-templates.php
@@ -70,6 +70,34 @@ class HTMLTemplates {
   }
 
   /**
+   * The template that is displayed in the comments section after a post is created
+   * with bad credentials.
+   * This template is displayed in the comments section when there is no `discourse_permalink`
+   * index in the response returned from `Discourse::sync_to_discourse_work`
+   * 
+   * Can be customized in the theme using the filter provided.
+   *
+   * @return mixed|void
+   */
+  public static function bad_response_html() {
+    ob_start();
+    ?>
+    <div class="respond comment-respond">
+      <h3 id="reply-title" class="comment-reply-title">
+        <?php _e( 'Start the discussion...', 'wp-discourse' ); ?>
+      </h3>
+      <div class="comment-reply-title no-connection-notice">
+        <p><?php _e( 'We are currently unable to connect with the Discourse forum. ' .
+                     'The site administrator has been notified. Please try again later.', 'wp-discourse' ); ?></p>
+      </div>
+    </div>
+    <?php
+    $output = ob_get_clean();
+
+    return apply_filters( 'discourse_no_connection_html', $output );
+  }
+
+  /**
    * HTML template for each comment
    *
    * Can be customized from within a theme using the filter provided.

--- a/lib/response-validator.php
+++ b/lib/response-validator.php
@@ -6,9 +6,7 @@ namespace WPDiscourse\ResponseValidator;
  * 
  * Validates the response from `wp_remote_get` and `wp_remote_post`.
  * Sets and gets the status of the connection to Discourse.
- * Runs a periodic check on the connection status.
  * 
- * @package WPDiscourse\ResponseValidator
  */
 class ResponseValidator {
   static protected $instance;
@@ -65,8 +63,8 @@ class ResponseValidator {
       return $this->validate( $response );
     }
   }
-
-  public function validate( $response, $update_status = true ) {
+  
+  public function validate( $response, $update_status = false ) {
     
     // There will be a WP_Error if the server can't be accessed
     if ( is_wp_error( $response ) ) {

--- a/lib/response-validator.php
+++ b/lib/response-validator.php
@@ -1,0 +1,97 @@
+<?php
+namespace WPDiscourse\ResponseValidator;
+
+/**
+ * Class ResponseValidator
+ * 
+ * Validates the response from `wp_remote_get` and `wp_remote_post`.
+ * Sets and gets the status of the connection to Discourse.
+ * Runs a periodic check on the connection status.
+ * 
+ * @package WPDiscourse\ResponseValidator
+ */
+class ResponseValidator {
+  static protected $instance;
+
+  public static function get_instance() {
+    if ( null == self::$instance ) {
+      self::$instance = new self();
+    }
+
+    return self::$instance;
+  }
+
+  private function __construct() {
+  }
+
+  public function set_status( $status ) {
+    set_transient( 'discourse_connection_status', $status );
+  }
+
+  public function get_status() {
+    return get_transient( 'discourse_connection_status' );
+  }
+
+  // Checks the connection status. If a period is given, only checks once per period.
+  public function check_connection_status( $period = null ) {
+    $options = get_option( 'discourse' );
+    $url     = array_key_exists( 'url', $options ) ? $options['url'] : '';
+    $url     = add_query_arg( array(
+      'api_key'      => array_key_exists( 'api-key', $options ) ? $options['api-key'] : '',
+      'api_username' => array_key_exists( 'publish-username', $options ) ? $options['publish-username'] : ''
+    ), $url . '/users/' . $options['publish-username'] .'.json' );
+    
+    $url = esc_url_raw( $url );
+    $time = date_create()->format( 'U' );
+
+    if ( $period ) {
+      // Check if it's time to update. 
+      if ( get_transient( 'discourse_last_status_update' ) === false ||
+           ( ( get_transient( 'discourse_last_status_update' ) + $period ) < $time ) ) {
+        $response = wp_remote_get( $url );
+        set_transient( 'discourse_last_status_update', $time );
+
+        return $this->validate( $response );
+      } else {
+        // It's not time to update yet, return the saved status.
+        return $this->get_status();
+      }
+
+    } else {
+      // No period has been set, so check the status now.
+      $response = wp_remote_get( $url );
+      set_transient( 'discourse_last_status_update', $time );
+
+      return $this->validate( $response );
+    }
+  }
+
+  public function validate( $response, $update_status = true ) {
+    
+    // There will be a WP_Error if the server can't be accessed
+    if ( is_wp_error( $response ) ) {
+      error_log( $response->get_error_message() );
+      if ( $update_status ) {
+        $this->set_status( 0 );
+      }
+
+      return 0;
+      
+      // There is a response from the server, but it's not what we're looking for.
+    } elseif ( wp_remote_retrieve_response_code( $response ) != 200 ) {
+      $error_message = wp_remote_retrieve_response_code( $response );
+      error_log( 'There has been a problem accessing your Discourse forum. Error Message: ' . $error_message );
+      if ( $update_status ) {
+        $this->set_status( 0 );
+      }
+
+      return 0;
+    }
+    // valid response
+    if ( $update_status ) {
+      $this->set_status( 1 );
+    }
+
+    return 1;
+  }
+}

--- a/lib/settings-validator.php
+++ b/lib/settings-validator.php
@@ -16,7 +16,7 @@ class SettingsValidator {
   public function __construct() {
     add_filter( 'validate_url', array( $this, 'validate_url' ) );
     add_filter( 'validate_api_key', array( $this, 'validate_api_key' ) );
-    add_filter( 'validate_publish_username', array(
+    add_filter( 'validate_publish_username', array( 
       $this,
       'validate_publish_username'
     ) );
@@ -272,7 +272,7 @@ class SettingsValidator {
   }
 
   public function validate_sso_secret( $input ) {
-    if ( strlen( sanitize_text_field( $input) ) >= 10 ) {
+    if ( strlen( sanitize_text_field( $input ) ) >= 10 ) {
       return sanitize_text_field( $input );
 
       // Only add a settings error if sso is enabled, otherwise just sanitize the input.
@@ -288,16 +288,19 @@ class SettingsValidator {
 
   public function validate_login_path( $input ) {
     if ( $this->sso_enabled && $input ) {
-      
+
       $regex = '/^\/([a-z0-9\-]+)*(\/[a-z0-9\-]+)*(\/)?$/';
       if ( ! preg_match( $regex, $input ) ) {
         add_settings_error( 'discourse', 'login_path', __( 'The path to login page setting needs to be a valid file path, starting with \'/\'.', 'wp-discourse' ) );
+
         return $this->sanitize_text( $input );
-        
+
       }
+
       // It's valid
       return $this->sanitize_text( $input );
     }
+
     // Sanitize, but don't validate. SSO is not enabled.
     return $this->sanitize_text( $input );
   }

--- a/templates/comments.php
+++ b/templates/comments.php
@@ -1,11 +1,12 @@
 <?php
 use WPDiscourse\Templates as Templates;
+use WPDiscourse\ResponseValidator as Validator;
 
 $custom = get_post_custom();
+$response_validator = Validator\ResponseValidator::get_instance();
 
-// If, when a new post id published to Discourse, there is not a valid response from
-// the forum, the `discourse_permalink` key will not be set. At this point there will
-// not be any comments. Display the `bad_response_html` template.
+// If, when a new post is published to Discourse, there is not a valid response from
+// the forum, the `discourse_permalink` key will not be set. Display the `bad_response_html` template.
 if ( ! array_key_exists( 'discourse_permalink', $custom ) ) {
   echo wp_kses_post( Templates\HTMLTemplates::bad_response_html() );
 
@@ -83,10 +84,10 @@ if ( ! array_key_exists( 'discourse_permalink', $custom ) ) {
       $participant_html = str_replace( '{username}', esc_html( $participant->username ), $participant_html );
       $participants_html .= $participant_html;
     }
-    $discourse_html = wp_kses_post( Templates\HTMLTemplates::replies_html() );
+    $discourse_html = wp_kses_post( Templates\HTMLTemplates::replies_html( $response_validator->get_status() ) );
     $discourse_html = str_replace( '{more_replies}', $more_replies, $discourse_html );
   } else {
-    $discourse_html = wp_kses_post( Templates\HTMLTemplates::no_replies_html() );
+    $discourse_html = wp_kses_post( Templates\HTMLTemplates::no_replies_html( $response_validator->get_status() ) );
   }
   $discourse_html = str_replace( '{discourse_url}', $discourse_url, $discourse_html );
   $discourse_html = str_replace( '{discourse_url_name}', $discourse_url_name, $discourse_html );

--- a/templates/comments.php
+++ b/templates/comments.php
@@ -1,9 +1,7 @@
 <?php
 use WPDiscourse\Templates as Templates;
-use WPDiscourse\ResponseValidator as Validator;
 
 $custom = get_post_custom();
-$response_validator = Validator\ResponseValidator::get_instance();
 
 // If, when a new post is published to Discourse, there is not a valid response from
 // the forum, the `discourse_permalink` key will not be set. Display the `bad_response_html` template.
@@ -84,10 +82,10 @@ if ( ! array_key_exists( 'discourse_permalink', $custom ) ) {
       $participant_html = str_replace( '{username}', esc_html( $participant->username ), $participant_html );
       $participants_html .= $participant_html;
     }
-    $discourse_html = wp_kses_post( Templates\HTMLTemplates::replies_html( $response_validator->get_status() ) );
+    $discourse_html = wp_kses_post( Templates\HTMLTemplates::replies_html() );
     $discourse_html = str_replace( '{more_replies}', $more_replies, $discourse_html );
   } else {
-    $discourse_html = wp_kses_post( Templates\HTMLTemplates::no_replies_html( $response_validator->get_status() ) );
+    $discourse_html = wp_kses_post( Templates\HTMLTemplates::no_replies_html() );
   }
   $discourse_html = str_replace( '{discourse_url}', $discourse_url, $discourse_html );
   $discourse_html = str_replace( '{discourse_url_name}', $discourse_url_name, $discourse_html );

--- a/templates/comments.php
+++ b/templates/comments.php
@@ -2,87 +2,96 @@
 use WPDiscourse\Templates as Templates;
 
 $custom = get_post_custom();
-$options = get_option('discourse');
-$is_enable_sso = (isset( $options['enable-sso'] ) && intval( $options['enable-sso'] ) == 1);
-$permalink = (string)$custom['discourse_permalink'][0];
-if($is_enable_sso) {
-  $permalink = esc_url($options['url']) . '/session/sso?return_path=' . $permalink;
-}
-$discourse_url_name = preg_replace( "(https?://)", "", esc_url( $options['url'] ) );
-if ( isset( $custom['discourse_comments_raw'] ) ) {
-  $discourse_info = json_decode( $custom['discourse_comments_raw'][0] );
+
+// If, when a new post id published to Discourse, there is not a valid response from
+// the forum, the `discourse_permalink` key will not be set. At this point there will
+// not be any comments. Display the `bad_response_html` template.
+if ( ! array_key_exists( 'discourse_permalink', $custom ) ) {
+  echo wp_kses_post( Templates\HTMLTemplates::bad_response_html() );
+
 } else {
-  $discourse_info = array();
-}
-$defaults = array(
-  'posts_count'  => 0,
-  'posts'        => array(),
-  'participants' => array()
-);
+  $options       = get_option( 'discourse' );
+  $is_enable_sso = ( isset( $options['enable-sso'] ) && intval( $options['enable-sso'] ) == 1 );
+  $permalink     = (string) $custom['discourse_permalink'][0];
+  if ( $is_enable_sso ) {
+    $permalink = esc_url( $options['url'] ) . '/session/sso?return_path=' . $permalink;
+  }
+  $discourse_url_name = preg_replace( "(https?://)", "", esc_url( $options['url'] ) );
+  if ( isset( $custom['discourse_comments_raw'] ) ) {
+    $discourse_info = json_decode( $custom['discourse_comments_raw'][0] );
+  } else {
+    $discourse_info = array();
+  }
+  $defaults = array(
+    'posts_count'  => 0,
+    'posts'        => array(),
+    'participants' => array()
+  );
 
 // add <time> tag to WP allowed html tags
-global $allowedposttags;
-$allowedposttags['time'] = array( 'datetime' => array() );
+  global $allowedposttags;
+  $allowedposttags['time'] = array( 'datetime' => array() );
 
 // use custom datetime format string if provided, else global date format
-$datetime_format = $options['custom-datetime-format'] == '' ? get_option( 'date_format' ) : $options['custom-datetime-format'];
+  $datetime_format = $options['custom-datetime-format'] == '' ? get_option( 'date_format' ) : $options['custom-datetime-format'];
 
 // Add some protection in the event our metadata doesn't look how we expect it to
-$discourse_info = (object) wp_parse_args( (array) $discourse_info, $defaults );
+  $discourse_info = (object) wp_parse_args( (array) $discourse_info, $defaults );
 
-$more_replies = ( $discourse_info->posts_count - count( $discourse_info->posts ) - 1 );
-$more         = count( $discourse_info->posts ) == 0 ? "" : "more ";
+  $more_replies = ( $discourse_info->posts_count - count( $discourse_info->posts ) - 1 );
+  $more         = count( $discourse_info->posts ) == 0 ? "" : "more ";
 
-if ( $more_replies == 0 ) {
-  $more_replies = "";
-} elseif ( $more_replies == 1 ) {
-  $more_replies = "1 " . $more . "reply";
-} else {
-  $more_replies = $more_replies . " " . $more . "replies";
-}
-
-$discourse_url     = esc_url( $options['url'] );
-$discourse_html    = '';
-$comments_html     = '';
-$participants_html = '';
-
-if ( count( $discourse_info->posts ) > 0 ) {
-  foreach ( $discourse_info->posts as &$post ) {
-    $comment_html = wp_kses_post( Templates\HTMLTemplates::comment_html() );
-    $comment_html = str_replace( '{discourse_url}', $discourse_url, $comment_html );
-    $comment_html = str_replace( '{discourse_url_name}', $discourse_url_name, $comment_html );
-    $comment_html = str_replace( '{topic_url}', $permalink, $comment_html );
-    $avatar_url = Discourse::avatar( $post->avatar_template, 64 );
-    $comment_html = str_replace( '{avatar_url}', esc_url( $avatar_url ), $comment_html );
-    $user_url = Discourse::homepage( $options['url'], $post );
-    $comment_html = str_replace( '{user_url}', esc_url( $user_url ), $comment_html );
-    $comment_html = str_replace( '{username}', esc_html( $post->username ), $comment_html );
-    $comment_html = str_replace( '{fullname}', esc_html( $post->name ), $comment_html );
-    $comment_body = Discourse::convert_relative_img_src_to_absolute( $discourse_url, $post->cooked );
-    $comment_html = str_replace( '{comment_body}', wp_kses_post( $comment_body ), $comment_html );
-    $comment_html = str_replace( '{comment_created_at}', mysql2date( $datetime_format, get_date_from_gmt( $post->created_at ) ), $comment_html );
-    $comments_html .= $comment_html;
+  if ( $more_replies == 0 ) {
+    $more_replies = "";
+  } elseif ( $more_replies == 1 ) {
+    $more_replies = "1 " . $more . "reply";
+  } else {
+    $more_replies = $more_replies . " " . $more . "replies";
   }
-  foreach ( $discourse_info->participants as &$participant ) {
-    $participant_html = wp_kses_post( Templates\HTMLTemplates::participant_html() );
-    $participant_html = str_replace( '{discourse_url}', $discourse_url, $participant_html );
-    $participant_html = str_replace( '{discourse_url_name}', $discourse_url_name, $participant_html );
-    $participant_html = str_replace( '{topic_url}', $permalink, $participant_html );
-    $avatar_url = Discourse::avatar( $participant->avatar_template, 64 );
-    $participant_html = str_replace( '{avatar_url}', esc_url( $avatar_url ), $participant_html );
-    $user_url = Discourse::homepage( $options['url'], $participant );
-    $participant_html = str_replace( '{user_url}', esc_url( $user_url ), $participant_html );
-    $participant_html = str_replace( '{username}', esc_html( $participant->username ), $participant_html );
-    $participants_html .= $participant_html;
+
+  $discourse_url     = esc_url( $options['url'] );
+  $discourse_html    = '';
+  $comments_html     = '';
+  $participants_html = '';
+
+  if ( count( $discourse_info->posts ) > 0 ) {
+    foreach ( $discourse_info->posts as &$post ) {
+      $comment_html = wp_kses_post( Templates\HTMLTemplates::comment_html() );
+      $comment_html = str_replace( '{discourse_url}', $discourse_url, $comment_html );
+      $comment_html = str_replace( '{discourse_url_name}', $discourse_url_name, $comment_html );
+      $comment_html = str_replace( '{topic_url}', $permalink, $comment_html );
+      $avatar_url   = Discourse::avatar( $post->avatar_template, 64 );
+      $comment_html = str_replace( '{avatar_url}', esc_url( $avatar_url ), $comment_html );
+      $user_url     = Discourse::homepage( $options['url'], $post );
+      $comment_html = str_replace( '{user_url}', esc_url( $user_url ), $comment_html );
+      $comment_html = str_replace( '{username}', esc_html( $post->username ), $comment_html );
+      $comment_html = str_replace( '{fullname}', esc_html( $post->name ), $comment_html );
+      $comment_body = Discourse::convert_relative_img_src_to_absolute( $discourse_url, $post->cooked );
+      $comment_html = str_replace( '{comment_body}', wp_kses_post( $comment_body ), $comment_html );
+      $comment_html = str_replace( '{comment_created_at}', mysql2date( $datetime_format, get_date_from_gmt( $post->created_at ) ), $comment_html );
+      $comments_html .= $comment_html;
+    }
+    foreach ( $discourse_info->participants as &$participant ) {
+      $participant_html = wp_kses_post( Templates\HTMLTemplates::participant_html() );
+      $participant_html = str_replace( '{discourse_url}', $discourse_url, $participant_html );
+      $participant_html = str_replace( '{discourse_url_name}', $discourse_url_name, $participant_html );
+      $participant_html = str_replace( '{topic_url}', $permalink, $participant_html );
+      $avatar_url       = Discourse::avatar( $participant->avatar_template, 64 );
+      $participant_html = str_replace( '{avatar_url}', esc_url( $avatar_url ), $participant_html );
+      $user_url         = Discourse::homepage( $options['url'], $participant );
+      $participant_html = str_replace( '{user_url}', esc_url( $user_url ), $participant_html );
+      $participant_html = str_replace( '{username}', esc_html( $participant->username ), $participant_html );
+      $participants_html .= $participant_html;
+    }
+    $discourse_html = wp_kses_post( Templates\HTMLTemplates::replies_html() );
+    $discourse_html = str_replace( '{more_replies}', $more_replies, $discourse_html );
+  } else {
+    $discourse_html = wp_kses_post( Templates\HTMLTemplates::no_replies_html() );
   }
-  $discourse_html = wp_kses_post( Templates\HTMLTemplates::replies_html() );
-  $discourse_html = str_replace( '{more_replies}', $more_replies, $discourse_html );
-} else {
-  $discourse_html = wp_kses_post( Templates\HTMLTemplates::no_replies_html() );
+  $discourse_html = str_replace( '{discourse_url}', $discourse_url, $discourse_html );
+  $discourse_html = str_replace( '{discourse_url_name}', $discourse_url_name, $discourse_html );
+  $discourse_html = str_replace( '{topic_url}', $permalink, $discourse_html );
+  $discourse_html = str_replace( '{comments}', $comments_html, $discourse_html );
+  $discourse_html = str_replace( '{participants}', $participants_html, $discourse_html );
+  echo $discourse_html;
 }
-$discourse_html = str_replace( '{discourse_url}', $discourse_url, $discourse_html );
-$discourse_html = str_replace( '{discourse_url_name}', $discourse_url_name, $discourse_html );
-$discourse_html = str_replace( '{topic_url}', $permalink, $discourse_html );
-$discourse_html = str_replace( '{comments}', $comments_html, $discourse_html );
-$discourse_html = str_replace( '{participants}', $participants_html, $discourse_html );
-echo $discourse_html;

--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -35,13 +35,15 @@ define( 'WPDISCOURSE_URL', plugins_url( '', __FILE__ ) );
 require_once( __DIR__ . '/lib/html-templates.php' );
 require_once( __DIR__ . '/lib/discourse.php' );
 require_once( __DIR__ . '/lib/settings-validator.php' );
+require_once( __DIR__ . '/lib/response-validator.php' );
 require_once( __DIR__ . '/lib/admin.php' );
 require_once( __DIR__ . '/lib/sso.php' );
 require_once( __DIR__ . '/lib/plugin-support/woocommerce_support.php' );
 
-$discourse = new Discourse();
+$discourse_response_validator = WPDiscourse\ResponseValidator\ResponseValidator::get_instance();
 $discourse_settings_validator = new WPDiscourse\Validator\SettingsValidator();
-$discourse_admin = new DiscourseAdmin();
+$discourse = new Discourse( $discourse_response_validator );
+$discourse_admin = new DiscourseAdmin( $discourse_response_validator );
 $woocommerce_support = new WPDiscourse\PluginSupport\WooCommerceSupport( $discourse );
 
 register_activation_hook( __FILE__, array( $discourse, 'install' ) );


### PR DESCRIPTION
- checks the array returned by `get_post_custom` in `comments.php` before displaying the comments template.

- Adds a `ResponseValidator` class that is used in `discourse.php` and `admin.php`. 

- Periodically checks the connection status with Discourse so that the post's Discourse permalink is not displayed if the forum can't be reached. (Maybe this isn't necessary)

![screenshot 2016-05-29 18 01 30](https://cloud.githubusercontent.com/assets/2975917/15637165/696fcae6-25c7-11e6-9eda-23c19722204f.png)


