### PR TITLE
[WIP] Use a meta-box for getting and saving the meta-data

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -150,7 +150,7 @@ class DiscourseAdmin {
 			'debug_mode_checkbox'
 		), 'discourse', 'discourse_comments' );
 
-		add_action( 'post_submitbox_misc_actions', array( $this, 'publish_to_discourse' ) );
+//		add_action( 'post_submitbox_misc_actions', array( $this, 'publish_to_discourse' ) );
 
 		add_filter( 'user_contactmethods', array( $this, 'extend_user_profile' ), 10, 1 );
 	}

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -150,7 +150,6 @@ class DiscourseAdmin {
 			'debug_mode_checkbox'
 		), 'discourse', 'discourse_comments' );
 
-//		add_action( 'post_submitbox_misc_actions', array( $this, 'publish_to_discourse' ) );
 
 		add_filter( 'user_contactmethods', array( $this, 'extend_user_profile' ), 10, 1 );
 	}
@@ -479,43 +478,7 @@ class DiscourseAdmin {
 		</div>
 		<?php
 	}
-
-	function publish_to_discourse() {
-		global $post;
-
-		$options = Discourse::get_plugin_options();
-
-		if ( in_array( $post->post_type, $options['allowed_post_types'] ) ) {
-			if ( $post->post_status == 'auto-draft' ) {
-				$value = $options['auto-publish'];
-			} else {
-				$value = get_post_meta( $post->ID, 'publish_to_discourse', true );
-			}
-
-			$categories = self::get_discourse_categories( '0' );
-			if ( is_wp_error( $categories ) ) {
-				echo '<span>' . __( 'Unable to retrieve Discourse categories. Please check the wp-discourse plugin settings page to establish a connection.', 'wp-discourse' ) . '</span>';
-			} else {
-
-				echo '<div class="misc-pub-section misc-pub-section-discourse">';
-				echo '<label>' . __( 'Publish to Discourse: ', 'wp-discourse' ) . '</label>';
-				echo '<input type="checkbox"' . ( ( $value == "1" ) ? ' checked="checked" ' : null ) . 'value="1" name="publish_to_discourse" />';
-				echo '</div>';
-
-				echo '<div class="misc-pub-section misc-pub-section-category">' .
-				     '<input type="hidden" name="showed_publish_option" value="1">';
-				echo '<label>' . __( 'Discourse Category: ', 'wp-discourse' ) . '</label>';
-
-				$publish_post_category = get_post_meta( $post->ID, 'publish_post_category', true );
-				$default_category      = isset( $options['publish-category'] ) ? $options['publish-category'] : '';
-				$selected              = ( ! empty( $publish_post_category ) ) ? $publish_post_category : $default_category;
-
-				self::option_input( 'publish_post_category', $categories, $selected );
-				echo '</div>';
-			}
-		}
-	}
-
+	
 	function connection_status_notice() {
 		if ( ! $this->response_validator->check_connection_status() ) {
 			add_action( 'admin_notices', array( $this, 'disconnected' ) );

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -360,6 +360,9 @@ class Discourse {
 	}
 
 	public function publish_on_save( $post_id, $post ) {
+		if ( wp_is_post_revision($post_id ) ) {
+			return;
+		}
 		$publish_to_discourse = get_post_meta( $post_id, 'publish_to_discourse', true );
 		if ( $publish_to_discourse && self::is_valid_sync_post_type( $post_id ) ) {
 			self::sync_to_discourse( $post_id, $post->post_title, $post->post_content );

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -74,6 +74,7 @@ class Discourse {
 		add_filter( 'login_url', array( $this, 'set_login_url' ), 10, 2 );
 
 		add_action( 'wp_enqueue_scripts', array( $this, 'discourse_comments_js' ) );
+		add_action( 'save_post', array( $this, 'publish_on_save' ), 10, 2 );
 		add_action( 'xmlrpc_publish_post', array( $this, 'xmlrpc_publish_post_to_discourse' ) );
 		add_action( 'transition_post_status', array( $this, 'publish_post_to_discourse' ), 10, 3 );
 		add_action( 'parse_query', array( $this, 'sso_parse_request' ) );
@@ -356,6 +357,13 @@ class Discourse {
 
 		// show the existing WP comments
 		return $old;
+	}
+
+	public function publish_on_save( $post_id, $post ) {
+		$publish_to_discourse = get_post_meta( $post_id, 'publish_to_discourse', true );
+		if ( $publish_to_discourse && self::is_valid_sync_post_type( $post_id ) ) {
+			self::sync_to_discourse( $post_id, $post->post_title, $post->post_content );
+		}
 	}
 
 	function publish_post_to_discourse( $new_status, $old_status, $post ) {

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -363,8 +363,10 @@ class Discourse {
 		if ( wp_is_post_revision($post_id ) ) {
 			return;
 		}
+
+		$post_is_published = 'publish' === get_post_status( $post_id );
 		$publish_to_discourse = get_post_meta( $post_id, 'publish_to_discourse', true );
-		if ( $publish_to_discourse && self::is_valid_sync_post_type( $post_id ) ) {
+		if ( $publish_to_discourse && $post_is_published && self::is_valid_sync_post_type( $post_id ) ) {
 			self::sync_to_discourse( $post_id, $post->post_title, $post->post_content );
 		}
 	}

--- a/lib/meta-box.php
+++ b/lib/meta-box.php
@@ -40,7 +40,7 @@ class MetaBox {
 
 		<label for="publish_to_discourse"><?php _e( 'Publish post to Discourse:', 'wp-discourse' ); ?>
 			<input type="checkbox" name="publish_to_discourse" id="publish_to_discourse" value="1"
-				<?php checked( $publish_to_discourse, 1 ); ?> >
+				<?php checked( $publish_to_discourse ); ?> >
 		</label>
 		<br>
 		<label for="publish_post_category"><?php _e( 'Category to publish to:', 'wp-discourse' ); ?>
@@ -71,15 +71,18 @@ class MetaBox {
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return 0;
 		}
+		
+		// Indicate that the post has been saved so that the meta-box gets its values from the meta-data instead of the defaults.
+		update_post_meta( $post_id, 'has_been_saved', 1 );
 
 		if ( isset( $_POST['publish_post_category'] ) ) {
-			update_post_meta( $post_id, 'has_been_saved', 1 );
 			update_post_meta( $post_id, 'publish_post_category', $_POST['publish_post_category'] );
 		}
 
 		if ( isset( $_POST['publish_to_discourse'] ) ) {
-			update_post_meta( $post_id, 'has_been_saved', 1);
 			update_post_meta( $post_id, 'publish_to_discourse', $_POST['publish_to_discourse'] );
+		} else {
+			update_post_meta( $post_id, 'publish_to_discourse', 0 );
 		}
 
 		return $post_id;

--- a/lib/meta-box.php
+++ b/lib/meta-box.php
@@ -1,0 +1,88 @@
+<?php
+namespace WPDiscourse\MetaBox;
+
+class MetaBox {
+	protected $options;
+	protected $admin;
+
+	public function __construct( $admin ) {
+		$this->options = get_option( 'discourse' );
+		$this->admin   = $admin;
+
+		add_action( 'add_meta_boxes', array( $this, 'add_meta_box' ) );
+		add_action( 'save_post', array( $this, 'save_meta_box' ) );
+	}
+
+	public function add_meta_box( $post_type ) {
+		if ( in_array( $post_type, $this->options['allowed_post_types'] ) ) {
+			add_meta_box( 'discourse-publish-meta-box', __( 'Publish to Discourse' ), array(
+				$this,
+				'render_meta_box'
+			), 'post', 'side', 'high', null );
+		}
+	}
+
+	public function render_meta_box( $post ) {
+		$categories = $this->admin->get_discourse_categories();
+		
+		// If the post has not yet been saved, use the default setting. If it has been saved use the meta value.
+		if ( ! get_post_meta( $post->ID, 'has_been_saved', true ) ) {
+			$selected_category = intval( $this->options['publish-category'] );
+			$publish_to_discourse = isset( $this->options['auto-publish'] ) ? intval( $this->options['auto-publish'] ) : 0;
+		} else {
+			$selected_category = get_post_meta( $post->ID, 'publish_post_category', true );
+			$publish_to_discourse = get_post_meta( $post->ID, 'publish_to_discourse', true );
+		}
+
+		ob_start();
+		wp_nonce_field( 'publish_to_discourse', 'publish_to_discourse_nonce' );
+		?>
+
+		<label for="publish_to_discourse"><?php _e( 'Publish post to Discourse:', 'wp-discourse' ); ?>
+			<input type="checkbox" name="publish_to_discourse" id="publish_to_discourse" value="1"
+				<?php checked( $publish_to_discourse, 1 ); ?> >
+		</label>
+		<br>
+		<label for="publish_post_category"><?php _e( 'Category to publish to:', 'wp-discourse' ); ?>
+			<select name="publish_post_category" id="publish_post_category">
+				<?php foreach ( $categories as $category ) : ?>
+					<option
+						value="<?php echo( esc_attr( $category['id'] ) ); ?>"
+						<?php selected( $selected_category, $category['id'] ); ?>>
+						<?php echo( esc_html( $category['name'] ) ); ?>
+					</option>
+				<?php endforeach; ?>
+			</select>
+		</label>
+
+		<?php
+		echo ob_get_clean();
+	}
+
+	function save_meta_box( $post_id ) {
+		if ( ! isset( $_POST['publish_to_discourse_nonce'] ) || ! wp_verify_nonce( $_POST['publish_to_discourse_nonce'], 'publish_to_discourse' ) ) {
+			return 0;
+		}
+
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return 0;
+		}
+
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return 0;
+		}
+
+		if ( isset( $_POST['publish_post_category'] ) ) {
+			update_post_meta( $post_id, 'has_been_saved', 1 );
+			update_post_meta( $post_id, 'publish_post_category', $_POST['publish_post_category'] );
+		}
+
+		if ( isset( $_POST['publish_to_discourse'] ) ) {
+			update_post_meta( $post_id, 'has_been_saved', 1);
+			update_post_meta( $post_id, 'publish_to_discourse', $_POST['publish_to_discourse'] );
+		}
+
+		return $post_id;
+	}
+
+}

--- a/lib/settings-validator.php
+++ b/lib/settings-validator.php
@@ -151,7 +151,7 @@ class SettingsValidator {
 	}
 
 	public function validate_publish_category( $input ) {
-		return sanitize_text_field( $input );
+		return intval( sanitize_text_field( $input ) );
 	}
 
 	public function validate_publish_category_update( $input ) {

--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -36,12 +36,14 @@ require_once( __DIR__ . '/lib/settings-validator.php' );
 require_once( __DIR__ . '/lib/response-validator.php' );
 require_once( __DIR__ . '/lib/admin.php' );
 require_once( __DIR__ . '/lib/sso.php' );
+require_once( __DIR__ . '/lib/meta-box.php' );
 require_once( __DIR__ . '/lib/plugin-support/woocommerce_support.php' );
 
 $discourse_response_validator = WPDiscourse\ResponseValidator\ResponseValidator::get_instance();
 $discourse_settings_validator = new WPDiscourse\Validator\SettingsValidator();
 $discourse                    = new Discourse( $discourse_response_validator );
 $discourse_admin              = new DiscourseAdmin( $discourse_response_validator );
+$discourse_admin_meta_box     = new WPDiscourse\MetaBox\MetaBox( $discourse_admin );
 $woocommerce_support          = new WPDiscourse\PluginSupport\WooCommerceSupport( $discourse );
 
 register_activation_hook( __FILE__, array( $discourse, 'install' ) );


### PR DESCRIPTION
Currently, the process for getting and saving the 'publish_post_category' and 'publish_to_discourse' post metadata is quite complicated. When the `discourse.php` file is checked against the WordPress coding standards, the functions `save_post_data`, `publish_post_to_discourse` and `publish_active` are all producing the error: `Processing form data without nonce verification.` This is from accessing properties of the `$_POST` object without first verifying the nonce.

The easiest solution seems to be to add a meta-box to the admin pages for the allowed post types, and then follow normal WordPress procedures for saving the metadata. The allows the `Discourse::publish_post_to_discourse` function to be simplified. The `save_post_data` and `publish_active` methods can be removed.

It looks like this:

![screenshot 2016-06-09 12 59 00](https://cloud.githubusercontent.com/assets/2975917/15944358/11850980-2e42-11e6-9240-f8db554e26ac.png)
