### PR TITLE
WordPress coding standards uninstall.php

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -1,5 +1,10 @@
 <?php
-// If uninstall not called from WordPress, then exit
+/**
+ * Uninstall the plugin.
+ *
+ * @package WPDiscourse
+ */
+
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }


### PR DESCRIPTION
This PR brings `uninstall.php` into compliance with the wp coding standards.