### PR TITLE
Allow redirect to Discourse without login

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -169,6 +169,11 @@ class DiscourseAdmin {
 			$this,
 			'debug_mode_checkbox',
 		), 'discourse', 'discourse_comments' );
+		
+		add_settings_field( 'discourse_redirect_without_login', __( 'Redirect Without Login', 'wp-discourse' ), array(
+			$this,
+			'redirect_without_login_checkbox',
+		), 'discourse', 'discourse_wp_sso' );
 	}
 
 	/**
@@ -387,6 +392,13 @@ class DiscourseAdmin {
 	 */
 	function only_show_moderator_liked_checkbox() {
 		self::checkbox_input( 'only-show-moderator-liked', __( 'Yes', 'wp-discourse' ) );
+	}
+	
+	/**
+	 * Outputs markup for the redirect-without-login checkbox.
+	 */
+	function redirect_without_login_checkbox() {
+		self::checkbox_input( 'redirect-without-login', __( 'Do not force login for link to Discourse comments thread (No effect if not using SSO)' ) );
 	}
 
 	/**

--- a/templates/comments.php
+++ b/templates/comments.php
@@ -19,7 +19,7 @@ if ( ! array_key_exists( 'discourse_permalink', $custom ) ) {
 	$options       = get_option( 'discourse' );
 	$is_enable_sso = ( isset( $options['enable-sso'] ) && 1 === intval( $options['enable-sso'] ) );
 	$permalink     = (string) $custom['discourse_permalink'][0];
-	if ( $is_enable_sso ) {
+	if ( $is_enable_sso && ! $options['redirect-without-login'] ) {
 		$permalink = esc_url( $options['url'] ) . '/session/sso?return_path=' . $permalink;
 	}
 	$discourse_url_name = preg_replace( '(https?://)', '', esc_url( $options['url'] ) );


### PR DESCRIPTION
if using SSO, the link that wp-discourse generates that sends the user to the Discourse thread to comment on the WP post ("continue the discussion in our forum"), forces the user to login before they are redirected to the Discourse thread.

i decided that i wanted to have the link redirect straight to the thread without an intervening login page. if the user wants to post when they get there, they can click the "login to reply" button in Discourse.

this patch adds a setting in the admin that allows this behavior (but leaves the default as-is).