### PR TITLE
FIX: Set expiration on transients

### DIFF
--- a/lib/discourse-comment.php
+++ b/lib/discourse-comment.php
@@ -114,7 +114,7 @@ class DiscourseComment {
 		if ( $debug || $last_sync + 60 * 10 < $time ) {
 			$lock = 'comments_locked_for_' . $postid;
 			if ( ! 'locked' === get_transient( $lock ) ) {
-				set_transient( $lock, 'locked', 600 );
+				set_transient( $lock, 'locked', 60 );
 
 				if ( 'publish' === get_post_status( $postid ) ) {
 

--- a/lib/discourse-comment.php
+++ b/lib/discourse-comment.php
@@ -114,7 +114,7 @@ class DiscourseComment {
 		if ( $debug || $last_sync + 60 * 10 < $time ) {
 			$lock = 'comments_locked_for_' . $postid;
 			if ( ! 'locked' === get_transient( $lock ) ) {
-				set_transient( $lock, 'locked' );
+				set_transient( $lock, 'locked', 600 );
 
 				if ( 'publish' === get_post_status( $postid ) ) {
 

--- a/lib/discourse-publish.php
+++ b/lib/discourse-publish.php
@@ -96,7 +96,7 @@ class DiscoursePublish {
 
 		// This avoids a double sync, just 1 is allowed to go through at a time.
 		if ( ! 'locked' === get_transient( $lock ) ) {
-			set_transient( $lock, 'locked' );
+			set_transient( $lock, 'locked', 60 );
 			$this->sync_to_discourse_work( $postid, $title, $raw );
 			delete_transient( $lock );
 		}


### PR DESCRIPTION
The functions  `sync_comments` and `sync_to_discourse` both set a WordPress transient to avoid making simultaneous api calls to Discourse. The transients are deleted after the api call, but if for some reason the functions calls aren't completed the posts are stuck in a locked state. This PR sets an expiration time on the transients.