### PR TITLE
Avatar template size filters

### DIFF
--- a/lib/discourse-comment-formatter.php
+++ b/lib/discourse-comment-formatter.php
@@ -116,7 +116,7 @@ class DiscourseCommentFormatter {
 				$comment_html   = str_replace( '{discourse_url_name}', $discourse_url_name, $comment_html );
 				$comment_html   = str_replace( '{topic_url}', $permalink, $comment_html );
 				$comment_html   = str_replace( '{comment_url}', $post_url, $comment_html );
-				$avatar_url     = $this->avatar( $post->avatar_template, 64 );
+				$avatar_url     = $this->avatar( $post->avatar_template, apply_filters( 'discourse_post_avatar_template_size', 64 ) );
 				$comment_html   = str_replace( '{avatar_url}', esc_url( $avatar_url ), $comment_html );
 				$user_url       = $this->homepage( $this->options['url'], $post );
 				$comment_html   = str_replace( '{user_url}', esc_url( $user_url ), $comment_html );
@@ -136,7 +136,7 @@ class DiscourseCommentFormatter {
 				$participant_html   = str_replace( '{discourse_url}', $discourse_url, $participant_html );
 				$participant_html   = str_replace( '{discourse_url_name}', $discourse_url_name, $participant_html );
 				$participant_html   = str_replace( '{topic_url}', $permalink, $participant_html );
-				$avatar_url         = $this->avatar( $participant->avatar_template, 64 );
+				$avatar_url         = $this->avatar( $participant->avatar_template, apply_filters( 'discourse_participant_avatar_template_size', 64 ) );
 				$participant_html   = str_replace( '{avatar_url}', esc_url( $avatar_url ), $participant_html );
 				$user_url           = $this->homepage( $this->options['url'], $participant );
 				$participant_html   = str_replace( '{user_url}', esc_url( $user_url ), $participant_html );

--- a/lib/discourse-comment-formatter.php
+++ b/lib/discourse-comment-formatter.php
@@ -116,7 +116,7 @@ class DiscourseCommentFormatter {
 				$comment_html   = str_replace( '{discourse_url_name}', $discourse_url_name, $comment_html );
 				$comment_html   = str_replace( '{topic_url}', $permalink, $comment_html );
 				$comment_html   = str_replace( '{comment_url}', $post_url, $comment_html );
-				$avatar_url     = $this->avatar( $post->avatar_template, apply_filters( 'discourse_avatar_template_size', 64 ) );
+				$avatar_url     = $this->avatar( $post->avatar_template, 64 );
 				$comment_html   = str_replace( '{avatar_url}', esc_url( $avatar_url ), $comment_html );
 				$user_url       = $this->homepage( $this->options['url'], $post );
 				$comment_html   = str_replace( '{user_url}', esc_url( $user_url ), $comment_html );
@@ -136,7 +136,7 @@ class DiscourseCommentFormatter {
 				$participant_html   = str_replace( '{discourse_url}', $discourse_url, $participant_html );
 				$participant_html   = str_replace( '{discourse_url_name}', $discourse_url_name, $participant_html );
 				$participant_html   = str_replace( '{topic_url}', $permalink, $participant_html );
-				$avatar_url         = $this->avatar( $participant->avatar_template, apply_filters( 'discourse_avatar_template_size', 64 ) );
+				$avatar_url         = $this->avatar( $participant->avatar_template, 64 );
 				$participant_html   = str_replace( '{avatar_url}', esc_url( $avatar_url ), $participant_html );
 				$user_url           = $this->homepage( $this->options['url'], $participant );
 				$participant_html   = str_replace( '{user_url}', esc_url( $user_url ), $participant_html );

--- a/lib/discourse-comment-formatter.php
+++ b/lib/discourse-comment-formatter.php
@@ -116,7 +116,7 @@ class DiscourseCommentFormatter {
 				$comment_html   = str_replace( '{discourse_url_name}', $discourse_url_name, $comment_html );
 				$comment_html   = str_replace( '{topic_url}', $permalink, $comment_html );
 				$comment_html   = str_replace( '{comment_url}', $post_url, $comment_html );
-				$avatar_url     = $this->avatar( $post->avatar_template, 64 );
+				$avatar_url     = $this->avatar( $post->avatar_template, apply_filters( 'discourse_avatar_template_size', 64 ) );
 				$comment_html   = str_replace( '{avatar_url}', esc_url( $avatar_url ), $comment_html );
 				$user_url       = $this->homepage( $this->options['url'], $post );
 				$comment_html   = str_replace( '{user_url}', esc_url( $user_url ), $comment_html );
@@ -136,7 +136,7 @@ class DiscourseCommentFormatter {
 				$participant_html   = str_replace( '{discourse_url}', $discourse_url, $participant_html );
 				$participant_html   = str_replace( '{discourse_url_name}', $discourse_url_name, $participant_html );
 				$participant_html   = str_replace( '{topic_url}', $permalink, $participant_html );
-				$avatar_url         = $this->avatar( $participant->avatar_template, 64 );
+				$avatar_url         = $this->avatar( $participant->avatar_template, apply_filters( 'discourse_avatar_template_size', 64 ) );
 				$participant_html   = str_replace( '{avatar_url}', esc_url( $avatar_url ), $participant_html );
 				$user_url           = $this->homepage( $this->options['url'], $participant );
 				$participant_html   = str_replace( '{user_url}', esc_url( $user_url ), $participant_html );

--- a/templates/html-templates.php
+++ b/templates/html-templates.php
@@ -67,7 +67,7 @@ class HTMLTemplates {
 			<div class="respond comment-respond">
 				<h3 id="reply-title" class="comment-reply-title">
 					<?php echo esc_html( self::get_text_options( 'continue-discussion-text' ) . ' ' ); ?>
-					<a <?php self::target(); ?> href="{topic_url}">
+					<a <?php echo self::target(); ?> href="{topic_url}">
 						{discourse_url_name}
 					</a>
 				</h3>
@@ -106,7 +106,7 @@ class HTMLTemplates {
 					$text = $discourse_comments_number > 0 ? self::get_text_options( 'join-discussion-text' ) : self::get_text_options( 'start-discussion-text' );
 					?>
 					<?php echo esc_html( $text ) . ' '; ?>
-					<a <?php self::target(); ?> href="{topic_url}">
+					<a <?php echo self::target(); ?> href="{topic_url}">
 						{discourse_url_name}
 					</a></h3>
 			</div>

--- a/templates/html-templates.php
+++ b/templates/html-templates.php
@@ -67,7 +67,7 @@ class HTMLTemplates {
 			<div class="respond comment-respond">
 				<h3 id="reply-title" class="comment-reply-title">
 					<?php echo esc_html( self::get_text_options( 'continue-discussion-text' ) . ' ' ); ?>
-					<a <?php echo self::target(); ?> href="{topic_url}">
+					<a <?php self::target(); ?> href="{topic_url}">
 						{discourse_url_name}
 					</a>
 				</h3>
@@ -106,7 +106,7 @@ class HTMLTemplates {
 					$text = $discourse_comments_number > 0 ? self::get_text_options( 'join-discussion-text' ) : self::get_text_options( 'start-discussion-text' );
 					?>
 					<?php echo esc_html( $text ) . ' '; ?>
-					<a <?php echo self::target(); ?> href="{topic_url}">
+					<a <?php self::target(); ?> href="{topic_url}">
 						{discourse_url_name}
 					</a></h3>
 			</div>


### PR DESCRIPTION
The default avatar image size and display size (within the comments template) are both 64px. On retina displays this looks blurry. The display can be adjusted smaller or larger than 64px with CSS or by filtering the comment html template (filter: discourse_comment_html). I couldn't figure out another way to adjust the size of the avatar image file besides adding a filter here.

I've created separate filters for posts and participants this time.