### PR TITLE
Fix truncated SSO redirection URL with non-latin characters

### DIFF
--- a/lib/sso-client/client.php
+++ b/lib/sso-client/client.php
@@ -379,11 +379,16 @@ class Client extends SSOClientBase {
 			// @codingStandardsIgnoreEnd
 		}
 
-		$sso = urldecode( sanitize_text_field( wp_unslash( $_GET['sso'] ) ) ); // Input var okay.
+		$sso = base64_decode( $_GET['sso'], true ); // Input var okay.
+
+		if ( ! $sso ) {
+			return null;
+		}
 
 		$response = array();
 
-		parse_str( base64_decode( $sso ), $response );
+		parse_str( $sso, $response );
+		$response = array_map( 'urldecode', $response );
 		$response = array_map( 'sanitize_text_field', $response );
 
 		if ( empty( $response['external_id'] ) ) {

--- a/lib/sso-client/query-redirect.php
+++ b/lib/sso-client/query-redirect.php
@@ -85,7 +85,7 @@ class QueryRedirect {
 		}
 
 		if ( ! empty( $_GET['redirect_to'] ) ) { // Input var okay.
-			$redirect_to = sanitize_text_field( wp_unslash( $_GET['redirect_to'] ) ); // Input var okay.
+			$redirect_to = esc_url_raw( wp_unslash( $_GET['redirect_to'] ) ); // Input var okay.
 		} else {
 			$redirect_to = home_url( '/' );
 		}
@@ -94,7 +94,7 @@ class QueryRedirect {
 			http_build_query(
 				array(
 					'nonce'          => Nonce::get_instance()->create( '_discourse_sso' ),
-					'return_sso_url' => $redirect_to,
+					'return_sso_url' => utf8_uri_encode( $redirect_to ),
 				)
 			)
 		);


### PR DESCRIPTION
Related to https://meta.discourse.org/t/sso-redirect-fails-for-non-latin-chars/101632.

This fixes the URL containing Unicode characters before the request is sent, and after the response is received.

* _Before the request_: The URL must be encoded with `utf8_uri_encode` before being sent to Discourse, otherwise, it will error that URI must be ASCII only. Also here we sanitize an URL, and therefore `esc_url_raw` should be used instead.
* _After the response_: `url_decode` is moved after the string is decoded (no effect before) and before `sanitize_text_field` to avoid the encoded characters starting with `%` to be filtered. To sanitize the `sso` param, `base64_decode` is retrieved/checked in strict mode before.



