### PR TITLE
Honor hide-discourse-name-field option on publisher's username retrieval (syncing topic)

### DIFF
--- a/lib/discourse-publish.php
+++ b/lib/discourse-publish.php
@@ -180,7 +180,11 @@ class DiscoursePublish {
 		$featured = wp_get_attachment_image_src( get_post_thumbnail_id( $post_id ), 'full' );
 		$baked    = str_replace( '{featuredimage}', '![image](' . $featured['0'] . ')', $baked );
 
-		$username = get_the_author_meta( 'discourse_username', $current_post->post_author );
+		$username = null;
+		if ( empty( $options['hide-discourse-name-field'] ) ) {
+			$username = get_the_author_meta( 'discourse_username', $current_post->post_author );
+		}
+
 		if ( ! $username || strlen( $username ) < 2 ) {
 			$username = $options['publish-username'];
 		}


### PR DESCRIPTION
If you have SSO configured, you have likely this `discourse_username` meta set and if the `Do Not Display Discourse Name Field` is set, you would expect that the publisher user name used to sync a topic will be the one defined by `Publishing Username`.