### PR TITLE
Move h2 out of table of user-profile.php

### DIFF
--- a/admin/user-profile.php
+++ b/admin/user-profile.php
@@ -57,8 +57,8 @@ class UserProfile {
 				$discourse_username_description = __( 'Used for publishing posts from WordPress to Discourse. Needs to match the username on Discourse.', 'wp-discourse' );
 			}
 			?>
+			<h2><?php esc_html_e( 'Discourse', 'wp-discourse' ); ?></h2>
 			<table class="form-table">
-				<h2><?php esc_html_e( 'Discourse', 'wp-discourse' ); ?></h2>
 				<?php
 				wp_nonce_field( 'update_discourse_usermeta', 'update_discourse_usermeta_nonce' );
 					$discourse_username = get_user_meta( $profile_user->ID, 'discourse_username', true );

--- a/lib/sync-discourse-user.php
+++ b/lib/sync-discourse-user.php
@@ -125,8 +125,6 @@ class SyncDiscourseUser extends Webhook {
 			}
 
 			if ( $wordpress_user && ! is_wp_error( $wordpress_user ) ) {
-				do_action( 'wpdc_webhook_before_update_user_data', $wordpress_user, $discourse_user, $event_type );
-				
 				$user_id = $wordpress_user->ID;
 				$this->update_user_data( $user_id, $discourse_user );
 			}

--- a/lib/sync-discourse-user.php
+++ b/lib/sync-discourse-user.php
@@ -140,6 +140,8 @@ class SyncDiscourseUser extends Webhook {
 	 * @param object $user_data The json data from the Discourse webhook.
 	 */
 	protected function update_user_data( $user_id, $user_data ) {
+		do_action( 'wpdc_webhook_update_user_data', $user_id, $user_data );
+		
 		$discourse_username = sanitize_text_field( $user_data['username'] );
 		$discourse_id       = intval( $user_data['id'] );
 

--- a/lib/sync-discourse-user.php
+++ b/lib/sync-discourse-user.php
@@ -125,6 +125,8 @@ class SyncDiscourseUser extends Webhook {
 			}
 
 			if ( $wordpress_user && ! is_wp_error( $wordpress_user ) ) {
+				do_action( 'wpdc_webhook_before_update_user_data', $wordpress_user, $discourse_user, $event_type );
+				
 				$user_id = $wordpress_user->ID;
 				$this->update_user_data( $user_id, $discourse_user );
 			}
@@ -140,8 +142,6 @@ class SyncDiscourseUser extends Webhook {
 	 * @param object $user_data The json data from the Discourse webhook.
 	 */
 	protected function update_user_data( $user_id, $user_data ) {
-		do_action( 'wpdc_webhook_update_user_data', $user_id, $user_data );
-		
 		$discourse_username = sanitize_text_field( $user_data['username'] );
 		$discourse_id       = intval( $user_data['id'] );
 


### PR DESCRIPTION
Headings are typically located outside of the tables for options on WP profile pages. (Thanks Simon!)