### PR TITLE
Add action hook before update_user_data (webhook)

### DIFF
--- a/lib/sync-discourse-user.php
+++ b/lib/sync-discourse-user.php
@@ -125,6 +125,8 @@ class SyncDiscourseUser extends Webhook {
 			}
 
 			if ( $wordpress_user && ! is_wp_error( $wordpress_user ) ) {
+				do_action( 'wpdc_webhook_before_update_user_data', $wordpress_user, $discourse_user, $event_type );
+
 				$user_id = $wordpress_user->ID;
 				$this->update_user_data( $user_id, $discourse_user );
 			}


### PR DESCRIPTION
I was looking for an action hook after we've determined the `$wordpress_user` variable. `wpdc_webhook_user_created` and `wpdc_webhook_user_updated` fire before this happens.

The hook might be more useful after `update_user_data`; either works for me.