### PR TITLE
Fix redirect URLs set by wp-login.php?redirect_to=...

### DIFF
--- a/lib/sso-client/sso-client-base.php
+++ b/lib/sso-client/sso-client-base.php
@@ -40,8 +40,17 @@ class SSOClientBase {
 			$anchor     = ! empty( $options['login'] ) ? $options['login'] : $login_text;
 		}
 
-		$redirect      = ! empty( $options['redirect'] ) ? $options['redirect'] : null;
-		$sso_login_url = $this->get_discourse_sso_url( $redirect );
+		if ( isset( $_GET['redirect_to'] ) ) {
+			$redirect_to = wp_validate_redirect(
+				esc_url_raw( $_GET['redirect_to'] ),
+				null
+			);
+		} else if ( ! empty( $options['redirect'] ) ) {
+			$redirect_to = $options['redirect'];
+		} else {
+			$redirect_to = null;
+		}
+		$sso_login_url = $this->get_discourse_sso_url( $redirect_to );
 
 		$anchor = apply_filters( 'wpdc_sso_client_login_anchor', $anchor );
 		$button = sprintf( '<a class="wpdc-sso-client-login-link" href="%s">%s</a>', esc_url( $sso_login_url ), sanitize_text_field( $anchor ) );
@@ -68,7 +77,10 @@ class SSOClientBase {
 		return add_query_arg(
 			array(
 				'discourse_sso' => sanitize_key( apply_filters( 'wpdc_sso_client_query', 1 ) ),
-				'redirect_to'   => esc_url( apply_filters( 'wpdc_sso_client_redirect_url', esc_url( $redirect_to ), $redirect_to ) ),
+				'redirect_to'   => apply_filters( 'wpdc_sso_client_redirect_url',
+					urlencode( esc_url_raw( $redirect_to ) ),
+					$redirect_to
+				),
 			),
 			home_url( '/' )
 		);

--- a/lib/sso-client/sso-client-base.php
+++ b/lib/sso-client/sso-client-base.php
@@ -42,7 +42,7 @@ class SSOClientBase {
 
 		if ( isset( $_GET['redirect_to'] ) ) {
 			$redirect_to = wp_validate_redirect(
-				esc_url_raw( $_GET['redirect_to'] ),
+				esc_url_raw( wp_unslash( $_GET['redirect_to'] ) ),
 				null
 			);
 		} else if ( ! empty( $options['redirect'] ) ) {


### PR DESCRIPTION
Someone might send you a link like the following:

`https://yourdomain.com/wp-admin/post.php?post=432&action=edit`

If you're not logged in and you click it, you'll get redirected to here:

`https://yourdomain.com/wp-login.php?redirect_to=https%3A%2F%2Fyourdomain.net%2Fwp-admin%2Fpost.php%3Fpost%3D432%26action%3Dedit&reauth=1`

When using Discourse as your SSO provider, this `redirect_to` argument is currently not passed through the SSO process, so you end up at `/wp-admin/` after logging in.

This PR validates the `redirect_to` argument and passes it through the Discourse SSO process, so that you end up back at the original URL after logging in.

It also fixes the escaping of the redirect URL so that URLs containing characters like `?` and `&` can work correctly.  `urlencode` is the right function to use for escaping something in a query parameter, and we can use `esc_url_raw` for additional validation/sanitization. `esc_url` as used before this change does not work correctly in this context.

Before this change, the SSO URL that gets visited when you click the link on the login page is the following: `https://yourdomain.com/?discourse_sso=1&redirect_to=https://yourdomain.com/wp-admin/post.php?post=432&#038;action=edit`. `&#038;` appears here due to the incorrect use of `esc_url`, and everything following the `#` character is truncated by the browser, so the `&action=edit` parameter is lost in the redirect.

After this change, the SSO URL is the following: `https://yourdomain.com/?discourse_sso=1&redirect_to=https%3A%2F%2Fyourdomain.net%2Fwp-admin%2Fpost.php%3Fpost%3D432%26action%3Dedit` (works as intended)