### PR TITLE
Don't use $array{0} syntax

### DIFF
--- a/lib/sso-client/client.php
+++ b/lib/sso-client/client.php
@@ -250,7 +250,7 @@ class Client extends SSOClientBase {
 				return $user_id;
 			}
 
-			return $user_query_results{0}->ID;
+			return $user_query_results[0]->ID;
 		}// End if().
 	}
 


### PR DESCRIPTION
This is deprecated in PHP 7.4.

Fixes #355.