### PR TITLE
Allow HTML 5 audio/video in comment

### DIFF
--- a/lib/discourse-comment.php
+++ b/lib/discourse-comment.php
@@ -57,6 +57,7 @@ class DiscourseComment {
 
 	/**
 	 * Adds data-youtube-id to the allowable div attributes.
+	 * Adds src to the allowable source attributes.
 	 *
 	 * Discourse returns the youtube video id as the value of the 'data-youtube-attribute',
 	 * this function makes it possible to filter the comments with `wp_kses_post` without
@@ -77,6 +78,10 @@ class DiscourseComment {
 				'role'            => true,
 				'data-youtube-id' => array(),
 			);
+
+			$allowedposttags['source'] = [
+				'src' => true,
+			];
 		}
 
 		return $allowedposttags;

--- a/lib/template-functions.php
+++ b/lib/template-functions.php
@@ -102,6 +102,17 @@ trait TemplateFunctions {
 			}
 		}
 
+		// HTML5 <source>
+		$images = $doc->getElementsByTagName( 'source' );
+		foreach ( $images as $image ) {
+			$src       = $image->getAttribute( 'src' );
+			$url_parts = wp_parse_url( $src );
+
+			if ( empty( $url_parts['host'] ) ) {
+				$image->setAttribute( 'src', $url . $src );
+			}
+		}
+
 		// Clear the libxml error buffer.
 		libxml_clear_errors();
 		// Restore the previous value of libxml_use_internal_errors.

--- a/lib/template-functions.php
+++ b/lib/template-functions.php
@@ -80,38 +80,26 @@ trait TemplateFunctions {
 		$doc = new \DOMDocument( '1.0', 'utf-8' );
 		$doc->loadHTML( mb_convert_encoding( $content, 'HTML-ENTITIES', 'UTF-8' ) );
 
-		// Mentions and hashtags.
-		$links = $doc->getElementsByTagName( 'a' );
-		foreach ( $links as $link ) {
-			$href      = $link->getAttribute( 'href' );
-			$url_parts = wp_parse_url( $href );
+		$set_tag_attribute = static function($tag, $attribute, $url ) use ( $doc ) {
+			$links = $doc->getElementsByTagName( $tag );
+			foreach ( $links as $link ) {
+				$href      = $link->getAttribute( $attribute );
+				$url_parts = wp_parse_url( $href );
 
-			if ( empty( $url_parts['host'] ) ) {
-				$link->setAttribute( 'href', $url . $href );
+				if ( empty( $url_parts['host'] ) ) {
+					$link->setAttribute( $attribute, $url . $href );
+				}
 			}
-		}
+		};
+
+		// Mentions and hashtags.
+		$set_tag_attribute( 'a', 'href', $url );
 
 		// Images, emojis etc.
-		$images = $doc->getElementsByTagName( 'img' );
-		foreach ( $images as $image ) {
-			$src       = $image->getAttribute( 'src' );
-			$url_parts = wp_parse_url( $src );
+		$set_tag_attribute( 'img', 'src', $url );
 
-			if ( empty( $url_parts['host'] ) ) {
-				$image->setAttribute( 'src', $url . $src );
-			}
-		}
-
-		// HTML5 <source>
-		$images = $doc->getElementsByTagName( 'source' );
-		foreach ( $images as $image ) {
-			$src       = $image->getAttribute( 'src' );
-			$url_parts = wp_parse_url( $src );
-
-			if ( empty( $url_parts['host'] ) ) {
-				$image->setAttribute( 'src', $url . $src );
-			}
-		}
+		// HTML5 audio/video
+		$set_tag_attribute( 'source', 'src', $url );
 
 		// Clear the libxml error buffer.
 		libxml_clear_errors();

--- a/lib/template-functions.php
+++ b/lib/template-functions.php
@@ -101,17 +101,11 @@ trait TemplateFunctions {
 		// HTML5 audio/video
 		$set_tag_attribute( 'source', 'src', $url );
 
-		// Clear the libxml error buffer.
-		libxml_clear_errors();
-		// Restore the previous value of libxml_use_internal_errors.
-		libxml_use_internal_errors( $use_internal_errors );
+		$this->clear_libxml_errors( $use_internal_errors, $disable_entity_loader );
 
 		$parsed = $doc->saveHTML( $doc->documentElement );
 
-		// Remove DOCTYPE, html, and body tags that have been added to the DOMDocument.
-		$parsed = preg_replace( '~<(?:!DOCTYPE|/?(?:html|body))[^>]*>\s*~i', '', $parsed );
-
-		return $parsed;
+		return $this->remove_outer_html_elements( $parsed );
 	}
 
 	/**


### PR DESCRIPTION
HTML 5  `<video>` and `<audio>` are supported by Discourse.
Currently, WP Discourse partially support them due to `wp_kses_post` filtering out `<source>` tag.

What does this PR:
* Allow `<source>`  and   `src` attribute
* Convert `src` relative URL to absolute