### PR TITLE
Allow HTML 5 audio/video in comment

### DIFF
--- a/lib/discourse-comment.php
+++ b/lib/discourse-comment.php
@@ -57,6 +57,7 @@ class DiscourseComment {
 
 	/**
 	 * Adds data-youtube-id to the allowable div attributes.
+	 * Adds src to the allowable source attributes.
 	 *
 	 * Discourse returns the youtube video id as the value of the 'data-youtube-attribute',
 	 * this function makes it possible to filter the comments with `wp_kses_post` without
@@ -77,6 +78,10 @@ class DiscourseComment {
 				'role'            => true,
 				'data-youtube-id' => array(),
 			);
+
+			$allowedposttags['source'] = [
+				'src' => true,
+			];
 		}
 
 		return $allowedposttags;

--- a/lib/template-functions.php
+++ b/lib/template-functions.php
@@ -100,6 +100,19 @@ trait TemplateFunctions {
 				$image->setAttribute( 'src', $url . $src );
 			}
 		}
+
+
+		// HTML 5 Video/Audio
+		$sources = $doc->getElementsByTagName( 'source' );
+		foreach ( $sources as $source ) {
+			$src       = $source->getAttribute( 'src' );
+			$url_parts = wp_parse_url( $src );
+
+			if ( empty( $url_parts['host'] ) ) {
+				$source->setAttribute( 'src', $url . $src );
+			}
+		}
+
 		$this->clear_libxml_errors( $use_internal_errors, $disable_entity_loader );
 
 		$parsed = $doc->saveHTML( $doc->documentElement );

--- a/lib/template-functions.php
+++ b/lib/template-functions.php
@@ -101,8 +101,7 @@ trait TemplateFunctions {
 			}
 		}
 
-
-		// HTML 5 Video/Audio
+		// HTML 5 Video/Audio.
 		$sources = $doc->getElementsByTagName( 'source' );
 		foreach ( $sources as $source ) {
 			$src       = $source->getAttribute( 'src' );


### PR DESCRIPTION
HTML 5  `<video>` and `<audio>` are supported by Discourse.
Currently, WP Discourse partially support them due to `wp_kses_post` filtering out `<source>` tag.

What does this PR:
* Allow `<source>`  and   `src` attribute
* Convert `src` relative URL to absolute

Sorry for the previous PR, not sure what's happened.