### PR TITLE
Improvements to get_discourse_groups

### DIFF
--- a/lib/utilities.php
+++ b/lib/utilities.php
@@ -692,10 +692,8 @@ class Utilities {
 			return new \WP_Error( 'wpdc_configuration_error', 'The Discourse Connection options are not properly configured.' );
 		}
 
-		$groups_url = esc_url_raw( $api_credentials['url'] . $path );
-
 		$response = wp_remote_get(
-			$groups_url,
+			esc_url_raw( $api_credentials['url'] . $path ),
 			array(
 				'headers' => array(
 					'Api-Key'      => sanitize_key( $api_credentials['api_key'] ),


### PR DESCRIPTION
1. Adds pagination of ``/groups`` discourse endpoint to ``get_discourse_groups`` Utilities function.
2. Adds generic ``discourse_request`` function for the immediate purpose of 1, and for future use in other Utilities functions.
3. Adds generic ``discourse_munge`` function for the handling of raw data models returned from discourse.