### PR TITLE
Restrict client from editing post metadata via standard api

### DIFF
--- a/admin/discourse-sidebar/discourse-sidebar.php
+++ b/admin/discourse-sidebar/discourse-sidebar.php
@@ -148,8 +148,9 @@ class DiscourseSidebar {
 					$post_type,
 					$meta_key,
 					array(
-						'single'       => true,
-						'show_in_rest' => true,
+						'single'        => true,
+						'show_in_rest'  => true,
+						'auth_callback' => __return_false(),
 					)
 				);
 			}


### PR DESCRIPTION
Restricts the client from updating post metadata via the standard wordpress object api. For @scossar.