### PR TITLE
Circumvent cache in publication logic metadata

### DIFF
--- a/admin/publish-settings.php
+++ b/admin/publish-settings.php
@@ -267,6 +267,17 @@ class PublishSettings {
 				'discourse_publish',
 				'discourse_publishing_settings_section'
 			);
+			
+			add_settings_field(
+				'discourse_direct_db_publication_flags',
+				__( 'Direct Database Publication Flags', 'wp-discourse' ),
+				array(
+					$this,
+					'direct_db_publication_flags',
+				),
+				'discourse_publish',
+				'discourse_publishing_settings_section'
+			);
 		}
 
 		register_setting(
@@ -524,6 +535,24 @@ class PublishSettings {
 			'allowed_post_types',
 			$this->form_helper->post_types_to_publish( array( 'attachment' ) ),
 			__( 'Hold the <strong>control</strong> button (Windows) or the <strong>command</strong> button (Mac) to select multiple post-types.', 'wp-discourse' )
+		);
+	}
+	
+	/**
+	 * Outputs markup for the discourse_direct_db_publication_meta checkbox.
+	 */
+	public function direct_db_publication_flags() {
+		$this->form_helper->checkbox_input(
+			'direct-db-publication-flags',
+			'discourse_publish',
+			__(
+				'Use direct database calls for flags that control publication to discourse (EXPERIMENTAL).',
+				'wp-discourse'
+			),
+			__(
+				"Potentially prevents concurrency issues arising from object cache usage.",
+				'wp-discourse'
+			)
 		);
 	}
 

--- a/admin/settings-validator.php
+++ b/admin/settings-validator.php
@@ -104,6 +104,7 @@ class SettingsValidator {
 		add_filter( 'wpdc_validate_publish_failure_email', array( $this, 'validate_email' ) );
 		add_filter( 'wpdc_validate_hide_discourse_name_field', array( $this, 'validate_checkbox' ) );
 		add_filter( 'wpdc_validate_discourse_username_editable', array( $this, 'validate_checkbox' ) );
+		add_filter( 'wpdc_validate_discourse_direct_db_publication_flags', array( $this, 'validate_checkbox' ) );
 
 		add_filter( 'wpdc_validate_enable_discourse_comments', array( $this, 'validate_checkbox' ) );
 		add_filter( 'wpdc_validate_comment_type', array( $this, 'validate_radio_string_value' ) );


### PR DESCRIPTION
@scossar Direct db meta functions have been changed to function that use normal wp methods unless the ``direct-db-publication-flags`` option is set. I've attempted to follow the exact approach you've used for options, however please let me know if I've missed something there.