### PR TITLE
add auto create wp user option

### DIFF
--- a/admin/sso-settings.php
+++ b/admin/sso-settings.php
@@ -238,6 +238,17 @@ class SSOSettings {
 			);
 
 			add_settings_field(
+				'discourse_auto_create_wp_user',
+				__( 'Create Wordpress Users', 'wp-discourse' ),
+				array(
+					$this,
+					'sso_client_auto_create_wp_user_checkbox',
+				),
+				'discourse_sso_client',
+				'discourse_sso_client_settings_section'
+			);
+
+			add_settings_field(
 				'discourse_enable_sso_sync',
 				__( 'Sync Existing Users by Email', 'wp-discourse' ),
 				array(
@@ -557,6 +568,17 @@ class SSOSettings {
 	}
 
 	/**
+	 * Outputs markup for sso-client-auto-create-wp-user checkbox.
+	 */
+	public function sso_client_auto_create_wp_user_checkbox() {
+		$this->form_helper->checkbox_input(
+			'sso-client-auto-create-wp-user',
+			'discourse_sso_client',
+			__( "If that user doesn't yet exist on your WordPress site, a new user will be created.", 'wp-discourse' )
+		);
+	}
+
+	/**
 	 * Outputs markup for sso-client-sync-by-email checkbox.
 	 */
 	public function sso_client_sync_by_email_checkbox() {
@@ -690,7 +712,7 @@ class SSOSettings {
 					"Enabling your site to function as an SSO client allows WordPress user authentication to be handled
                 through either your Discourse forum, or your WordPress site. If a Discourse user logs into WordPress through an SSO link,
                 they will be authenticated based on their Discourse credentials. If that user doesn't yet exist on your WordPress site, a new
-                user will be created.",
+                user will be optionally created.",
 					'wp-discourse'
 				);
 				?>

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -163,6 +163,7 @@ class Discourse {
 		'sso-client-enabled'             => 0,
 		'sso-client-login-form-change'   => 0,
 		'sso-client-login-form-redirect' => '',
+		'sso-client-auto-create-wp-user' => 0,
 		'sso-client-sync-by-email'       => 0,
 		'sso-client-sync-logout'         => 0,
 	);

--- a/lib/sso-client/client.php
+++ b/lib/sso-client/client.php
@@ -189,7 +189,7 @@ class Client extends SSOClientBase {
 	 *
 	 * For non-logged-in users, the function checks if there's an existing user with the payload's 'discourse_sso_user_id',
 	 * if there isn't, there is an optional check for a user with a matching email address. If both checks fail, a new user
-	 * is created.
+	 * is optionally created.
 	 *
 	 * @return int|\WP_Error
 	 */
@@ -236,7 +236,7 @@ class Client extends SSOClientBase {
 				}
 			}
 
-			if ( empty( $user_query_results ) ) {
+			if ( empty( $user_query_results ) && ! empty( $this->options['sso-client-auto-create-wp-user'] ) ) {
 				$user_password = wp_generate_password( 12, true );
 
 				$user_id = wp_create_user(
@@ -248,6 +248,10 @@ class Client extends SSOClientBase {
 				do_action( 'wpdc_sso_client_after_create_user', $user_id );
 
 				return $user_id;
+			}
+
+			if ( empty( $user_query_results ) ) {
+				return new \WP_Error( 'no_such_user' );
 			}
 
 			return $user_query_results[0]->ID;


### PR DESCRIPTION
Consider the following situation:
1. A user uses Discourse to login Wordpress
2. Sync with email is enabled
3. However, the user does not exist in Wordpress yet

In the current design, a new user will always be created in Wordpress.  This is undesirable in the case when the site admin would like to allow only certain Discourse users to login to Wordpress (as content managers/admin/etc).

Therefore, this pull request adds a checkbox option.  The Wordpress admin may decide whether a new user should be created in Wordpress.  The Wordpress admin may manually create Wordpress users for the other content managers/admins who may login using Discourse.