### PR TITLE
Add wpdc_comments_count filter

### DIFF
--- a/lib/discourse-comment.php
+++ b/lib/discourse-comment.php
@@ -394,6 +394,6 @@ class DiscourseComment {
 			}
 		}
 
-		return $count;
+		return apply_filters( 'wpdc_comments_count', $count, $post_id, $discourse_post_id );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: discourse, forum, comments, sso
 Requires at least: 4.7
 Tested up to: 5.7
 Requires PHP: 5.6.0
-Stable tag: 2.2.2
+Stable tag: 2.2.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -122,6 +122,10 @@ To create a coherent top menu, see our tutorial on how to make a [Custom nav hea
 8. Configuring the plugin: the SSO Client settings tab.
 
 == Changelog ==
+
+#### 2.2.3 04/05/2021
+
+- Add `wpdc_comments_count` filter to allow comments count for posts that have not been published to Discourse to be filtered
 
 #### 2.2.2 03/19/2021
 

--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WP-Discourse
  * Description: Use Discourse as a community engine for your WordPress blog
- * Version: 2.2.2
+ * Version: 2.2.3
  * Author: Discourse
  * Text Domain: wp-discourse
  * Domain Path: /languages
@@ -34,7 +34,7 @@ define( 'WPDISCOURSE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WPDISCOURSE_URL', plugins_url( '', __FILE__ ) );
 define( 'MIN_WP_VERSION', '4.7' );
 define( 'MIN_PHP_VERSION', '5.6.0' );
-define( 'WPDISCOURSE_VERSION', '2.2.2' );
+define( 'WPDISCOURSE_VERSION', '2.2.3' );
 
 require_once WPDISCOURSE_PATH . 'lib/plugin-utilities.php';
 require_once WPDISCOURSE_PATH . 'lib/template-functions.php';


### PR DESCRIPTION
This PR adds a `wpdc_comments_count` filter to allow comment counts for posts that have not been published to Discourse to be filtered. That feature was requested by a customer.

The PR also bumps the plugin's version to `2.2.3`