### PR TITLE
PERF: use ajax tags autocomplete instead of tag list

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -60,7 +60,7 @@ function enqueue_admin_scripts() {
 	wp_enqueue_style( 'admin_styles' );
 
 	$script_path = '/js/admin.js';
-	wp_register_script( 'admin_js', plugins_url( $script_path, __FILE__ ), array( 'jquery' ), filemtime( plugin_dir_path( __FILE__ ) . $script_path ), true );
+	wp_register_script( 'admin_js', plugins_url( $script_path, __FILE__ ), array( 'jquery', 'tags-box' ), filemtime( plugin_dir_path( __FILE__ ) . $script_path ), true );
 	wp_enqueue_script( 'admin_js' );
 	$commenting_options = get_option( 'discourse-comment' );
 	$max_tags           = ! isset( $commenting_options['max-tags'] ) ? 5 : $commenting_options['max-tags'];

--- a/admin/css/admin-styles.css
+++ b/admin/css/admin-styles.css
@@ -268,3 +268,11 @@ button.wpdc-remove-tag:hover .wpdc-remove-tag-icon:before {
 #wpdc-log-viewer.loading pre {
 	visibility: hidden;
 }
+
+#wpdc-tags-select {
+	display: inline-block;
+}
+
+#wpdc-tags-select .newtag {
+	width: 350px;
+}

--- a/admin/form-helper.php
+++ b/admin/form-helper.php
@@ -170,23 +170,25 @@ class FormHelper {
 	 * Outputs the tag select input.
 	 *
 	 * @param string $option Used to set the selected option.
-	 * @param array  $tags An array of available tags.
+	 * @param string $option_group The option group of the settings field.
 	 * @param string $description The description of the settings field.
 	 */
-	public function tags_select_input( $option, $tags, $description = '' ) {
-		$options = $this->options;
-		$allowed = array(
-			'strong' => array(),
-		);
+	public function tags_select_input( $option, $option_group, $description = '' ) {
+		$options 	= $this->options;
+		$tax_name	= 'post_tag';
+		$comma		= _x( ',', 'tag delimiter' );
+		$selected = isset( $options[ $option ] ) ? $options[ $option ] : array();
+		$value		= join( "$comma ", $selected );
+		$name			= $this->option_name( $option, $option_group );
 
-		if ( empty( $tags ) ) {
-			echo '<p class="no-tags">' . esc_html_e( 'No tags to select.', 'wp-discourse' ) . '</p>';
-		} else {
-			echo "<select multiple id='discourse-exclude-tags' class='discourse-select-input' name='discourse_publish[exclude_tags][]'>";
-			$this->select_options( $option, $tags );
-			echo '</select>';
-			echo '<p class="description">' . wp_kses( $description, $allowed ) . '</p>';
-		}
+		?>
+			<div class="tagsdiv" id="wpdc-tags-select">
+				<div class="ajaxtag">
+					<input data-wp-taxonomy="<?php echo $tax_name; ?>" type="text" id="discourse-<?php echo $option; ?>" name="<?php echo $name; ?>" class="newtag form-input-tip" size="16" autocomplete="off" value="<?php echo esc_attr( $value ); ?>" />
+				</div>
+			</div>
+			<p class="description"><?php echo $description; ?></p>
+		<?php
 	}
 
 	/**
@@ -279,22 +281,6 @@ class FormHelper {
 		}
 
 		return apply_filters( 'discourse_post_types_to_publish', $post_types );
-	}
-
-	/**
-	 * Returns post tags ordered by name
-	 *
-	 * @return array
-	 */
-	public function post_tags() {
-		$tags = get_tags(
-			array(
-			    'taxonomy' => 'post_tag',
-			    'orderby'  => 'name',
-			)
-		);
-
-		return apply_filters( 'discourse_tags_to_publish', $tags );
 	}
 
 	/**

--- a/admin/form-helper.php
+++ b/admin/form-helper.php
@@ -174,20 +174,20 @@ class FormHelper {
 	 * @param string $description The description of the settings field.
 	 */
 	public function tags_select_input( $option, $option_group, $description = '' ) {
-		$options 	= $this->options;
-		$tax_name	= 'post_tag';
-		$comma		= _x( ',', 'tag delimiter' );
+		$options  = $this->options;
+		$tax_name = 'post_tag';
+		$comma    = _x( ',', 'tag delimiter' );
 		$selected = isset( $options[ $option ] ) ? $options[ $option ] : array();
-		$value		= join( "$comma ", $selected );
-		$name			= $this->option_name( $option, $option_group );
+		$value    = join( "$comma ", $selected );
+		$name     = $this->option_name( $option, $option_group );
 
 		?>
 			<div class="tagsdiv" id="wpdc-tags-select">
 				<div class="ajaxtag">
-					<input data-wp-taxonomy="<?php echo $tax_name; ?>" type="text" id="discourse-<?php echo $option; ?>" name="<?php echo $name; ?>" class="newtag form-input-tip" size="16" autocomplete="off" value="<?php echo esc_attr( $value ); ?>" />
+					<input data-wp-taxonomy="<?php echo esc_attr( $tax_name ); ?>" type="text" id="discourse-<?php echo esc_attr( $option ); ?>" name="<?php echo esc_attr( $name ); ?>" class="newtag form-input-tip" size="16" autocomplete="off" value="<?php echo esc_attr( $value ); ?>" />
 				</div>
 			</div>
-			<p class="description"><?php echo $description; ?></p>
+			<p class="description"><?php echo esc_attr( $description ); ?></p>
 		<?php
 	}
 

--- a/admin/js/admin.js
+++ b/admin/js/admin.js
@@ -229,4 +229,8 @@
 		xhr.responseType = 'arraybuffer';
 		xhr.send();
 	});
+	
+	if ( $('.tagsdiv').length ) {
+		window.tagBox && window.tagBox.init();
+	}
 })( jQuery );

--- a/admin/publish-settings.php
+++ b/admin/publish-settings.php
@@ -568,8 +568,8 @@ class PublishSettings {
 	public function tags_select() {
 		$this->form_helper->tags_select_input(
 			'exclude_tags',
-			$this->form_helper->post_tags(),
-			__( 'Do not auto-publish posts to Discourse if they have one of these tags. Hold the <strong>control</strong> button (Windows) or the <strong>command</strong> button (Mac) to select multiple tags.', 'wp-discourse' )
+			'discourse_publish',
+			__( 'Do not auto-publish posts to Discourse if they have one of these tags.', 'wp-discourse' )
 		);
 	}
 

--- a/admin/settings-validator.php
+++ b/admin/settings-validator.php
@@ -100,6 +100,7 @@ class SettingsValidator {
 		add_filter( 'wpdc_validate_add_featured_link', array( $this, 'validate_checkbox' ) );
 		add_filter( 'wpdc_validate_auto_track', array( $this, 'validate_checkbox' ) );
 		add_filter( 'wpdc_validate_allowed_post_types', array( $this, 'validate_allowed_post_types' ) );
+		add_filter( 'wpdc_validate_exclude_tags', array( $this, 'validate_exclude_tags' ) );
 		add_filter( 'wpdc_validate_publish_failure_notice', array( $this, 'validate_checkbox' ) );
 		add_filter( 'wpdc_validate_publish_failure_email', array( $this, 'validate_email' ) );
 		add_filter( 'wpdc_validate_hide_discourse_name_field', array( $this, 'validate_checkbox' ) );
@@ -290,6 +291,42 @@ class SettingsValidator {
 		}
 
 		return $output;
+	}
+
+	/**
+	 * Validates the 'exclude_tags' input.
+	 *
+	 * @param mixed $input The excluded tags.
+	 *
+	 * @return array
+	 */
+	public function validate_exclude_tags( $input ) {
+		$output = array();
+
+		if ( is_string( $input ) ) {
+			$input  = explode( ',', $input );
+		}
+
+		foreach ( $input as $tag_slug ) {
+			$tag_slug = trim( $tag_slug );
+
+			if ( $tag_slug == '' ) {
+				continue;
+			}
+
+			if ( term_exists( $tag_slug, 'post_tag' ) ) {
+				$output[] = sanitize_text_field( $tag_slug );
+			} else {
+				add_settings_error(
+					'discourse_exclude_tags',
+					'tag-does-not-exist',
+					"Exclude Posts By Tag: '$tag_slug' is not a valid tag.",
+					'warning'
+				);
+			}
+		}
+
+		return array_unique( $output );
 	}
 
 	/**

--- a/admin/settings-validator.php
+++ b/admin/settings-validator.php
@@ -310,7 +310,7 @@ class SettingsValidator {
 		foreach ( $input as $tag_slug ) {
 			$tag_slug = trim( $tag_slug );
 
-			if ( $tag_slug == '' ) {
+			if ( '' == $tag_slug ) {
 				continue;
 			}
 

--- a/lib/discourse-publish.php
+++ b/lib/discourse-publish.php
@@ -766,14 +766,15 @@ class DiscoursePublish {
 		if ( empty( $post_tags ) || is_wp_error( $post_tags ) ) {
 			return false;
 		}
-		$post_tag_ids = wp_list_pluck( $post_tags, 'term_id' );
 
-		$excluded_tag_ids = $this->get_excluded_tag_ids();
-		if ( empty( $excluded_tag_ids ) ) {
+		$excluded_tag_slugs = $this->get_excluded_tag_slugs();
+		if ( empty( $excluded_tag_slugs ) ) {
 			return false;
 		}
 
-		return count( array_intersect( $post_tag_ids, $excluded_tag_ids ) ) > 0;
+		$post_tag_slugs = wp_list_pluck( $post_tags, 'slug' );
+
+		return count( array_intersect( $post_tag_slugs, $excluded_tag_slugs ) ) > 0;
 	}
 
 	/**
@@ -798,11 +799,11 @@ class DiscoursePublish {
 	 *
 	 * @return mixed
 	 */
-	protected function get_excluded_tag_ids() {
+	protected function get_excluded_tag_slugs() {
 		if ( isset( $this->options['exclude_tags'] ) && is_array( $this->options['exclude_tags'] ) ) {
-			$exclude_tags = $this->options['exclude_tags'];
+			$excluded_tag_slugs = $this->options['exclude_tags'];
 
-			return $exclude_tags;
+			return $excluded_tag_slugs;
 		} else {
 			return array();
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: discourse, forum, comments, sso
 Requires at least: 4.7
 Tested up to: 5.8
 Requires PHP: 5.6.0
-Stable tag: 2.2.8
+Stable tag: 2.2.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -123,7 +123,11 @@ To create a coherent top menu, see our tutorial on how to make a [Custom nav hea
 
 == Changelog ==
 
-#### 2.2.7 01/05/2021
+#### 2.2.9 01/05/2021
+
+- Add performance improvement for exclude-by-tag publishing feature
+
+#### 2.2.8 01/05/2021
 
 - Add exclude-by-tag publishing feature (>= WP 5.6)
 

--- a/tests/phpunit/test-discourse-publish.php
+++ b/tests/phpunit/test-discourse-publish.php
@@ -464,16 +464,16 @@ class DiscoursePublishTest extends UnitTest {
         if ( ! $excluded_term ) {
           $excluded_term = wp_insert_term( 'dont_publish', 'post_tag' );
         }
-        $excluded_term_id = $excluded_term['term_id'];
+        $excluded_term = get_tag( $excluded_term['term_id'] );
+        $excluded_term_slug = $excluded_term->slug;
 
-        // Enable direct db pubilcation flags option.
-        self::$plugin_options['exclude_tags'] = array( $excluded_term_id );
+        // Enable exclude_tags option.
+        self::$plugin_options['exclude_tags'] = array( $excluded_term_slug );
         $this->publish->setup_options( self::$plugin_options );
 
         // Set up a response body for creating a new post.
         $body                = $this->mock_remote_post_success( 'post_create' );
-        $discourse_post_id   = $body->id;
-        $discourse_category  = self::$post_atts['tags_input'] = array( $excluded_term_id );
+        self::$post_atts['tags_input'] = array( $excluded_term_slug );
 
         // Add the post.
         $post_id = wp_insert_post( self::$post_atts, false, false );
@@ -488,7 +488,7 @@ class DiscoursePublishTest extends UnitTest {
 
         // Cleanup.
         wp_delete_post( $post_id );
-        wp_delete_term( $excluded_term_id, 'post_tags' );
+        wp_delete_term( $excluded_term->ID, 'post_tags' );
     }
 
     /**
@@ -500,23 +500,25 @@ class DiscoursePublishTest extends UnitTest {
         if ( ! $term ) {
           $term = wp_insert_term( 'publish', 'post_tag' );
         }
-        $term_id = $term['term_id'];
+        $term = get_tag( $term['term_id'] );
+        $term_slug = $term->slug;
 
         // Create the exclusionary tag
         $excluded_term = term_exists( 'dont_publish', 'post_tag' );
         if ( ! $excluded_term ) {
           $excluded_term = wp_insert_term( 'dont_publish', 'post_tag' );
         }
-        $excluded_term_id = $excluded_term['term_id'];
+        $excluded_term = get_tag( $excluded_term['term_id'] );
+        $excluded_term_slug = $excluded_term->slug;
 
-        // Enable direct db pubilcation flags option.
-        self::$plugin_options['exclude_tags'] = array( $excluded_term_id );
+        // Enable excluded tags option.
+        self::$plugin_options['exclude_tags'] = array( $excluded_term_slug );
         $this->publish->setup_options( self::$plugin_options );
 
         // Set up a response body for creating a new post.
         $body                = $this->mock_remote_post_success( 'post_create' );
         $discourse_post_id   = $body->id;
-        $discourse_category  = self::$post_atts['tags_input'] = array( $term_id );
+        self::$post_atts['tags_input'] = array( $term_slug );
 
         // Add the post.
         $post_id = wp_insert_post( self::$post_atts, false, false );
@@ -531,8 +533,8 @@ class DiscoursePublishTest extends UnitTest {
 
         // Cleanup.
         wp_delete_post( $post_id );
-        wp_delete_term( $term_id, 'post_tags' );
-        wp_delete_term( $excluded_term_id, 'post_tags' );
+        wp_delete_term( $term->ID, 'post_tags' );
+        wp_delete_term( $excluded_term->ID, 'post_tags' );
     }
 
     /**

--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WP-Discourse
  * Description: Use Discourse as a community engine for your WordPress blog
- * Version: 2.2.8
+ * Version: 2.2.9
  * Author: Discourse
  * Text Domain: wp-discourse
  * Domain Path: /languages
@@ -34,7 +34,7 @@ define( 'WPDISCOURSE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WPDISCOURSE_URL', plugins_url( '', __FILE__ ) );
 define( 'MIN_WP_VERSION', '4.7' );
 define( 'MIN_PHP_VERSION', '5.6.0' );
-define( 'WPDISCOURSE_VERSION', '2.2.8' );
+define( 'WPDISCOURSE_VERSION', '2.2.9' );
 
 require_once WPDISCOURSE_PATH . 'lib/plugin-utilities.php';
 require_once WPDISCOURSE_PATH . 'lib/template-functions.php';


### PR DESCRIPTION
For exclude by tag publishing setting
- Uses ajax autocomplete, utilising core wordpress ``tags-box.js``, ``tags-suggest`` and ``ajax-tag-search``
- Use tag slugs instead of ids in ``discourse-publish``