### PR TITLE
Adopt Discourse appraoch to tag cleaning

### DIFF
--- a/admin/discourse-sidebar/src/index.js
+++ b/admin/discourse-sidebar/src/index.js
@@ -59,6 +59,8 @@ const upArrow = ( <svg
     </g>
 </svg> );
 
+const tagsFilterRegExp = /[\/\?#\[\]@!\$&'\(\)\*\+,;=\.%\\`^\s|\{\}"<>]+/;
+
 class Notification extends Component {
     constructor( props ) {
         super( props );
@@ -446,9 +448,8 @@ class TagTopic extends Component {
     }
 
     handleKeyPress( e ) {
-        const keyVal = e.key,
-            val = e.target.value,
-            allowedChars = new RegExp("^[a-zA-Z0-9À-ž\-\_ ]+$");
+        let keyVal = e.key,
+            val = e.target.value;
 
         if ( 'Enter' === keyVal || ',' === keyVal ) {
             let currentChoices = this.state.chosenTags;
@@ -459,8 +460,11 @@ class TagTopic extends Component {
                 } );
                 return null;
             }
-            if ( allowedChars.test( val ) ) {
-                currentChoices.push( val.trim().replace( / /g, '-' ) );
+
+            val = this.cleanTag(val);
+
+            if ( val.length ) {
+                currentChoices.push( val );
                 currentChoices = TagTopic.sanitizeArray( currentChoices );
                 this.setState( {
                     chosenTags: currentChoices,
@@ -474,6 +478,15 @@ class TagTopic extends Component {
                 });
             }
         }
+    }
+
+    // see discourse/lib/discourse_tagging.rb#clean_tag
+    cleanTag( val ) {
+      val = val.trim(); // remove surrounding whitespace
+      val = val.replace( / /g, '-' ); // replace whitespace with hyphen
+      val = val.replace( /(-)\1+/g, '-'); // remove duplicate hyphens
+      val = val.replace( new RegExp(tagsFilterRegExp, 'g'), '' ); // remove special characters
+      return val;
     }
 
     handleClick( key ) {

--- a/admin/discourse-sidebar/src/index.js
+++ b/admin/discourse-sidebar/src/index.js
@@ -448,7 +448,7 @@ class TagTopic extends Component {
     handleKeyPress( e ) {
         const keyVal = e.key,
             val = e.target.value,
-            allowedChars = new RegExp("^[a-zA-Z0-9\-\_ ]+$");
+            allowedChars = new RegExp("^[a-zA-Z0-9À-ž\-\_ ]+$");
 
         if ( 'Enter' === keyVal || ',' === keyVal ) {
             let currentChoices = this.state.chosenTags;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: discourse, forum, comments, sso
 Requires at least: 4.7
 Tested up to: 5.8
 Requires PHP: 5.6.0
-Stable tag: 2.3.0
+Stable tag: 2.3.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -122,6 +122,10 @@ To create a coherent top menu, see our tutorial on how to make a [Custom nav hea
 8. Configuring the plugin: the DiscourseConnect Client settings tab.
 
 == Changelog ==
+
+#### 2.3.1 08/31/2021
+
+- Adopt Discourse approach to tag cleaning, including diacritic support
 
 #### 2.3.0 07/26/2021
 

--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WP-Discourse
  * Description: Use Discourse as a community engine for your WordPress blog
- * Version: 2.3.0
+ * Version: 2.3.1
  * Author: Discourse
  * Text Domain: wp-discourse
  * Domain Path: /languages
@@ -34,7 +34,7 @@ define( 'WPDISCOURSE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WPDISCOURSE_URL', plugins_url( '', __FILE__ ) );
 define( 'MIN_WP_VERSION', '4.7' );
 define( 'MIN_PHP_VERSION', '5.6.0' );
-define( 'WPDISCOURSE_VERSION', '2.3.0' );
+define( 'WPDISCOURSE_VERSION', '2.3.1' );
 
 require_once WPDISCOURSE_PATH . 'lib/plugin-utilities.php';
 require_once WPDISCOURSE_PATH . 'lib/template-functions.php';


### PR DESCRIPTION
Uses the same approach as https://github.com/discourse/discourse/blob/main/lib/discourse_tagging.rb#L464

* Adds support for diacritics. See https://meta.discourse.org/t/tags-and-at-least-scandinavian-alphabets/201771
* Formats tags according to how they will appear in Discourse (e.g. replacing whitepsace with hyphens)