### PR TITLE
IMPROVE: add translation pipeline for configurable text

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/lib/discourse-comment-formatter.php
+++ b/lib/discourse-comment-formatter.php
@@ -58,7 +58,7 @@ class DiscourseCommentFormatter {
 		}
 
 		if ( ! empty( $options['discourse-link-text'] ) ) {
-			$discourse_url_name = esc_html( $options['discourse-link-text'] );
+			$discourse_url_name = esc_html( self::get_text_options( 'discourse-link-text' ) );
 		} else {
 			$discourse_url_name = preg_replace( '(https?://)', '', esc_url( $options['url'] ) );
 		}
@@ -67,13 +67,13 @@ class DiscourseCommentFormatter {
 		$datetime_format = empty( $options['custom-datetime-format'] ) ? get_option( 'date_format' ) : $options['custom-datetime-format'];
 
 		$more_replies_number = intval( ( $topic_data->filtered_posts_count - count( $topic_data->posts ) - 1 ) );
-		$more_text           = esc_html( strtolower( $options['more-replies-more-text'] ) ) . ' ';
+		$more_text           = esc_html( strtolower( self::get_text_options( 'more-replies-more-text' ) ) ) . ' ';
 		if ( 0 >= $more_replies_number ) {
 			$more_replies = '';
 		} elseif ( 1 === $more_replies_number ) {
-			$more_replies = '1 ' . $more_text . esc_html( strtolower( $options['single-reply-text'] ) );
+			$more_replies = '1 ' . $more_text . esc_html( strtolower( self::get_text_options( 'single-reply-text' ) ) );
 		} else {
-			$more_replies = $more_replies_number . ' ' . $more_text . esc_html( strtolower( $options['many-replies-text'] ) );
+			$more_replies = $more_replies_number . ' ' . $more_text . esc_html( strtolower( self::get_text_options( 'many-replies-text' ) ) );
 		}
 
 		$discourse_url     = esc_url( $options['url'] );
@@ -173,13 +173,13 @@ class DiscourseCommentFormatter {
 
 		switch ( $comments_count ) {
 			case 0:
-				$link_text = $options['no-comments-text'];
+				$link_text = self::get_text_options( 'no-comments-text' );
 				break;
 			case 1:
-				$link_text = '1 ' . $options['comments-singular-text'];
+				$link_text = '1 ' . self::get_text_options( 'comments-singular-text' );
 				break;
 			default:
-				$link_text = $comments_count . ' ' . $options['comments-plural-text'];
+				$link_text = $comments_count . ' ' . self::get_text_options( 'comments-plural-text' );
 		}
 
 		$link_text = apply_filters( 'wpdc_join_discussion_link_text', $link_text, $comments_count, $post_id );

--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -112,7 +112,7 @@ class Discourse {
 		'more-replies-more-text'      => 'more',
 		'external-login-text'         => 'Log in with Discourse',
 		'link-to-discourse-text'      => 'Link your account to Discourse',
-		'linked-to-discourse-text'    => "You're account is linked with Discourse!",
+		'linked-to-discourse-text'    => 'Your account is linked with Discourse!',
 	);
 
 	/**
@@ -203,7 +203,6 @@ class Discourse {
 		$discourse_url = ! empty( $this->options['url'] ) ? $this->options['url'] : null;
 		$domain_name   = wp_parse_url( $discourse_url, PHP_URL_HOST );
 		update_option( 'wpdc_discourse_domain', $domain_name );
-
 		update_option( 'discourse_option_groups', $this->discourse_option_groups );
 
 		foreach ( $this->discourse_option_groups as $group_name ) {
@@ -211,6 +210,7 @@ class Discourse {
 				$saved_values   = get_option( 'discourse_configurable_text' );
 				$default_values = $this->discourse_configurable_text;
 				$merged_values  = array_merge( $default_values, $saved_values );
+				array_walk( $merged_values, 'self::register_text_translations' );
 				update_option( $group_name, $merged_values );
 			} else {
 				add_option( $group_name, $this->$group_name );

--- a/lib/plugin-utilities.php
+++ b/lib/plugin-utilities.php
@@ -13,6 +13,47 @@ namespace WPDiscourse\Shared;
 trait PluginUtilities {
 
 	/**
+	 * Gets the 'discourse_configurable_text' options.
+	 *
+	 * @param string $option The option key.
+	 *
+	 * @return string
+	 */
+	protected static function get_text_options( $option ) {
+		$text_options = get_option( 'discourse_configurable_text' );
+		$text         = ! empty( $text_options[ $option ] ) ? $text_options[ $option ] : '';
+		return self::apply_text_translations( $text, $option );
+	}
+
+	/**
+	 * Applies translations of configurable text.
+	 *
+	 * @param string $text The text to be translated.
+	 * @param string $option The text option to be translated.
+	 *
+	 * @return string
+	 */
+	protected static function apply_text_translations( $text, $option ) {
+		// See https://wpml.org/wpml-hook/wpml_translate_single_string/.
+		$text = apply_filters( 'wpml_translate_single_string', $text, 'wp-discourse', $option );
+
+		return $text;
+	}
+
+	/**
+	 * Registers translations of configurable text.
+	 *
+	 * @param string $text The text to be translated.
+	 * @param string $option The text option to be translated.
+	 *
+	 * @return void
+	 */
+	 protected static function register_text_translations( $text, $option ) {
+		 // See https://wpml.org/wpml-hook/wpml_register_single_string/.
+		 do_action( 'wpml_register_single_string', 'wp-discourse', $option, $text );
+	 }
+
+	/**
 	 * Returns a single array of options from a given array of arrays.
 	 *
 	 * @return array

--- a/lib/sso-client/client.php
+++ b/lib/sso-client/client.php
@@ -107,8 +107,8 @@ class Client extends SSOClientBase {
 	 */
 	public function discourse_sso_alter_user_profile() {
 		$auto_inject_button = $this->discourse_sso_auto_inject_button();
-		$link_text          = ! empty( $this->options['link-to-discourse-text'] ) ? $this->options['link-to-discourse-text'] : '';
-		$linked_text        = ! empty( $this->options['linked-to-discourse-text'] ) ? $this->options['linked-to-discourse-text'] : '';
+		$link_text          = ! empty( self::get_text_options( 'link-to-discourse-text' ) ) ? self::get_text_options( 'link-to-discourse-text' ) : '';
+		$linked_text        = ! empty( self::get_text_options( 'linked-to-discourse-text' ) ) ? self::get_text_options( 'linked-to-discourse-text' ) : '';
 		$user               = wp_get_current_user();
 
 		if ( ! apply_filters( 'wpdc_sso_client_add_link_buttons_on_profile', $auto_inject_button ) ) {

--- a/lib/sso-client/sso-client-base.php
+++ b/lib/sso-client/sso-client-base.php
@@ -33,10 +33,10 @@ class SSOClientBase {
 
 				return null;
 			}
-			$link_account_text = ! empty( $discourse_options['link-to-discourse-text'] ) ? $discourse_options['link-to-discourse-text'] : '';
+			$link_account_text = ! empty( self::get_text_options( 'link-to-discourse-text' ) ) ? self::get_text_options( 'link-to-discourse-text' ) : '';
 			$anchor            = ! empty( $options['link'] ) ? $options['link'] : $link_account_text;
 		} else {
-			$login_text = ! empty( $discourse_options['external-login-text'] ) ? $discourse_options['external-login-text'] : '';
+			$login_text = ! empty( self::get_text_options( 'external-login-text' ) ) ? self::get_text_options( 'external-login-text' ) : '';
 			$anchor     = ! empty( $options['login'] ) ? $options['login'] : $login_text;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: discourse, forum, comments, sso
 Requires at least: 4.7
 Tested up to: 5.8
 Requires PHP: 5.6.0
-Stable tag: 2.3.1
+Stable tag: 2.3.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -122,6 +122,11 @@ To create a coherent top menu, see our tutorial on how to make a [Custom nav hea
 8. Configuring the plugin: the DiscourseConnect Client settings tab.
 
 == Changelog ==
+
+#### 2.3.2 10/07/2021
+
+- Add translation pipeline for configurable text
+- Support WPML in translation pipeline for configurable text
 
 #### 2.3.1 08/31/2021
 

--- a/templates/html-templates.php
+++ b/templates/html-templates.php
@@ -11,25 +11,13 @@
 
 namespace WPDiscourse\Templates;
 
+use WPDiscourse\Shared\PluginUtilities;
+
 /**
  * Class HTMLTemplates
  */
 class HTMLTemplates {
-
-	/**
-	 * Gets the 'discourse_configurable_text' options.
-	 *
-	 * @param string $option The option key.
-	 *
-	 * @return string
-	 */
-	protected static function get_text_options( $option ) {
-		$text_options = get_option( 'discourse_configurable_text' );
-
-		$text = ! empty( $text_options[ $option ] ) ? $text_options[ $option ] : '';
-
-		return $text;
-	}
+	use PluginUtilities;
 
 	/**
 	 * Sets the value of the target attribute.

--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WP-Discourse
  * Description: Use Discourse as a community engine for your WordPress blog
- * Version: 2.3.1
+ * Version: 2.3.2
  * Author: Discourse
  * Text Domain: wp-discourse
  * Domain Path: /languages
@@ -34,7 +34,7 @@ define( 'WPDISCOURSE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WPDISCOURSE_URL', plugins_url( '', __FILE__ ) );
 define( 'MIN_WP_VERSION', '4.7' );
 define( 'MIN_PHP_VERSION', '5.6.0' );
-define( 'WPDISCOURSE_VERSION', '2.3.1' );
+define( 'WPDISCOURSE_VERSION', '2.3.2' );
 
 require_once WPDISCOURSE_PATH . 'lib/plugin-utilities.php';
 require_once WPDISCOURSE_PATH . 'lib/template-functions.php';


### PR DESCRIPTION
@scossar See https://meta.discourse.org/t/how-to-translate-text-content-in-wp-discourse/202326

~~In draft as this PR needs to be merged first to preserve version sequence: https://github.com/discourse/wp-discourse/pull/421~~