### PR TITLE
DEV: data-* attributes are now allowed by default

### DIFF
--- a/lib/discourse-comment.php
+++ b/lib/discourse-comment.php
@@ -53,7 +53,6 @@ class DiscourseComment {
 		add_filter( 'get_comments_number', array( $this, 'get_comments_number' ), 10, 2 );
 		add_action( 'wpdc_sync_discourse_comments', array( $this, 'sync_comments' ) );
 		add_filter( 'comments_template', array( $this, 'comments_template' ), 20, 1 );
-		add_filter( 'wp_kses_allowed_html', array( $this, 'extend_allowed_html' ), 10, 2 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'discourse_comments_js' ) );
 		add_action( 'rest_api_init', array( $this, 'initialize_comment_route' ) );
 	}
@@ -78,33 +77,6 @@ class DiscourseComment {
 	 */
 	public function setup_logger() {
 		$this->logger = Logger::create( 'comment' );
-	}
-
-	/**
-	 * Adds data-youtube-id to the allowable div attributes.
-	 *
-	 * Discourse returns the youtube video id as the value of the 'data-youtube-attribute',
-	 * this function makes it possible to filter the comments with `wp_kses_post` without
-	 * stripping out that attribute.
-	 *
-	 * @param array  $allowedposttags The array of allowed post tags.
-	 * @param string $context The current context ('post', 'data', etc.).
-	 *
-	 * @return mixed
-	 */
-	public function extend_allowed_html( $allowedposttags, $context ) {
-		if ( 'post' === $context ) {
-			$allowedposttags['div'] = array(
-				'class'           => true,
-				'id'              => true,
-				'style'           => true,
-				'title'           => true,
-				'role'            => true,
-				'data-youtube-id' => array(),
-			);
-		}
-
-		return $allowedposttags;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: discourse, forum, comments, sso
 Requires at least: 4.7
 Tested up to: 5.8
 Requires PHP: 5.6.0
-Stable tag: 2.3.1
+Stable tag: 2.3.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -122,6 +122,19 @@ To create a coherent top menu, see our tutorial on how to make a [Custom nav hea
 8. Configuring the plugin: the DiscourseConnect Client settings tab.
 
 == Changelog ==
+
+#### 2.3.4 10/30/2021
+
+- Improve comment HTML tag sanitization
+
+#### 2.3.3 10/29/2021
+
+- Update Discourse API key help text
+
+#### 2.3.2 10/07/2021
+
+- Add translation pipeline for configurable text
+- Support WPML in translation pipeline for configurable text
 
 #### 2.3.1 08/31/2021
 

--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WP-Discourse
  * Description: Use Discourse as a community engine for your WordPress blog
- * Version: 2.3.1
+ * Version: 2.3.4
  * Author: Discourse
  * Text Domain: wp-discourse
  * Domain Path: /languages
@@ -34,7 +34,7 @@ define( 'WPDISCOURSE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WPDISCOURSE_URL', plugins_url( '', __FILE__ ) );
 define( 'MIN_WP_VERSION', '4.7' );
 define( 'MIN_PHP_VERSION', '5.6.0' );
-define( 'WPDISCOURSE_VERSION', '2.3.1' );
+define( 'WPDISCOURSE_VERSION', '2.3.4' );
 
 require_once WPDISCOURSE_PATH . 'lib/plugin-utilities.php';
 require_once WPDISCOURSE_PATH . 'lib/template-functions.php';


### PR DESCRIPTION
See https://core.trac.wordpress.org/changeset/43981. Note that the existing usage can cause issues with data attributes used by other plugins, e.g: https://meta.discourse.org/t/discourse-wp-plugin-blocking-paypal-installation-in-easy-digital-downloads-wp-plugin/206172