### PR TITLE
FIX: Use correct verb for sync_sso request

### DIFF
--- a/lib/plugin-utilities.php
+++ b/lib/plugin-utilities.php
@@ -50,10 +50,10 @@ trait PluginUtilities {
 	 *
 	 * @return void
 	 */
-	 protected static function register_text_translations( $text, $option ) {
+	protected static function register_text_translations( $text, $option ) {
 		// See https://wpml.org/wpml-hook/wpml_register_single_string/.
 		do_action( 'wpml_register_single_string', 'wp-discourse', $option, $text );
-	 }
+	}
 
 	/**
 	 * Returns a single array of options from a given array of arrays.
@@ -328,10 +328,13 @@ trait PluginUtilities {
 			'sso' => $sso_payload,
 			'sig' => $sig,
 		);
-		$response_body = $this->discourse_request( $path, array(
-		    'type' => 'post',
-		    'body' => $body,
-        ) );
+		$response_body = $this->discourse_request(
+			$path,
+			array(
+				'type' => 'post',
+				'body' => $body,
+			)
+		);
 
 		if ( is_wp_error( $response_body ) ) {
 			return $response_body;

--- a/lib/plugin-utilities.php
+++ b/lib/plugin-utilities.php
@@ -328,7 +328,10 @@ trait PluginUtilities {
 			'sso' => $sso_payload,
 			'sig' => $sig,
 		);
-		$response_body = $this->discourse_request( $path, array( 'body' => $body ) );
+		$response_body = $this->discourse_request( $path, array(
+		    'type' => 'post',
+		    'body' => $body,
+        ) );
 
 		if ( is_wp_error( $response_body ) ) {
 			return $response_body;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: discourse, forum, comments, sso
 Requires at least: 4.7
 Tested up to: 5.8
 Requires PHP: 5.6.0
-Stable tag: 2.3.5
+Stable tag: 2.3.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -122,6 +122,10 @@ To create a coherent top menu, see our tutorial on how to make a [Custom nav hea
 8. Configuring the plugin: the DiscourseConnect Client settings tab.
 
 == Changelog ==
+
+#### 2.3.6 12/06/2021
+
+- Fix wrong verb being used in `sync_sso` request
 
 #### 2.3.5 11/17/2021
 

--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WP-Discourse
  * Description: Use Discourse as a community engine for your WordPress blog
- * Version: 2.3.5
+ * Version: 2.3.6
  * Author: Discourse
  * Text Domain: wp-discourse
  * Domain Path: /languages
@@ -34,7 +34,7 @@ define( 'WPDISCOURSE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WPDISCOURSE_URL', plugins_url( '', __FILE__ ) );
 define( 'MIN_WP_VERSION', '4.7' );
 define( 'MIN_PHP_VERSION', '5.6.0' );
-define( 'WPDISCOURSE_VERSION', '2.3.5' );
+define( 'WPDISCOURSE_VERSION', '2.3.6' );
 
 require_once WPDISCOURSE_PATH . 'lib/plugin-utilities.php';
 require_once WPDISCOURSE_PATH . 'lib/template-functions.php';


### PR DESCRIPTION
The new logging feature also introduced consolidating requests into `discourse_request` however, we forgot to ensure that we're using the correct verb for `sync_sso`.