### PR TITLE
Update workflows and documentation

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: PHP ${{ matrix.php }}
+    name: Formatting on PHP ${{ matrix.php }}
     strategy:
       matrix:
         include:

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,0 +1,59 @@
+name: WP-Discourse Formatting
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: PHP ${{ matrix.php }}
+    strategy:
+      matrix:
+        include:
+          - php: "5.6"
+            sniff: true
+          - php: "7.0"
+            sniff: true
+          - php: "7.4"
+            sniff: true
+            jshint: true
+          - php: "8.0"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Syntax Check
+        run: |
+          find -L . -name '*.php' -not -path "./vendor/*" -print0 | xargs -0 -n 1 -P 4 php -l
+
+      - name: Install Composer
+        if: "matrix.sniff"
+        uses: ramsey/composer-install@v1
+        with:
+          dependency-versions: "highest"
+          composer-options: "--ignore-platform-reqs"
+
+      - name: Install PHPEnv
+        if: "matrix.sniff"
+        run: |
+          git clone --depth 1 git://github.com/phpenv/phpenv.git ~/.phpenv
+          export PATH="$HOME/.phpenv/bin:$PATH"
+          phpenv rehash
+
+      - name: WordPress Coding Standards
+        if: "matrix.sniff"
+        run: |
+          vendor/bin/phpcs -p -s -v -n .
+
+      - name: JSHint
+        if: "matrix.jshint"
+        run: |
+          sudo npm install -g jshint
+          wget https://develop.svn.wordpress.org/trunk/.jshintrc
+          jshint .

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -59,7 +59,7 @@ jobs:
               let base_var = process.env[`base_${variable}`];
               let type = variable.split('_')[1];
 
-              if (type === 'version) {
+              if (type === 'version') {
                 if (semver.lte(head_var, base_var)) {
                   core.setFailed(`Head ${variable} is less than or equal to base ${variable}.`);
                 }

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -22,9 +22,7 @@ jobs:
       - name: Checkout base repository
         uses: actions/checkout@v2
         with:
-          repository: "${{ github.repository }}"
           ref: "${{ github.base_ref }}"
-          token: "${{ github.token }}"
 
       - name: Store base versions
         run: |

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -22,7 +22,9 @@ jobs:
       - name: Checkout base repository
         uses: actions/checkout@v2
         with:
+          repository: "${{ github.repository }}"
           ref: "${{ github.base_ref }}"
+          token: "${{ github.token }}"
 
       - name: Store base versions
         run: |

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -12,7 +12,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14
-          cache: 'npm'
       - run: npm install --include=dev
 
       - name: Checkout head repository

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -1,4 +1,4 @@
-name: Metadata
+name: WP Discourse Metadata
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    name: Metadata
     steps:
       - name: Checkout head repository
         uses: actions/checkout@v2

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -1,0 +1,76 @@
+name: Metadata
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout head repository
+        uses: actions/checkout@v2
+
+      - name: Store head versions
+        run: |
+          echo "head_readme_version=$(grep -Pio -m 1 '(?<=Stable tag: )(\d\.\d\.\d)' readme.txt)" >> $GITHUB_ENV
+          echo "head_change_version=$(grep -Pio -m 1 '(?<=#### )(\d\.\d\.\d)' readme.txt)" >> $GITHUB_ENV
+          echo "head_change_date=$(grep -Pio -m 1 "(?<=#### (\d\.\d\.\d) )(\d\d\/\d\d\/\d\d\d\d)" readme.txt)" >> $GITHUB_ENV
+          echo "head_plugin_version=$(grep -Pio -m 1 "(?<=Version: )(\d\.\d\.\d)" wp-discourse.php)" >> $GITHUB_ENV
+          echo "head_constant_version=$(grep -Pio -m 1 "(?<=WPDISCOURSE_VERSION\'\, \')(\d\.\d\.\d)" wp-discourse.php)" >> $GITHUB_ENV
+
+      - name: Checkout base repository
+        uses: actions/checkout@v2
+        with:
+          ref: "${{ github.base_ref }}"
+
+      - name: Store base versions
+        run: |
+          echo "base_readme_version=$(grep -Pio -m 1 '(?<=Stable tag: )(\d\.\d\.\d)' readme.txt)" >> $GITHUB_ENV
+          echo "base_change_version=$(grep -Pio -m 1 '(?<=#### )(\d\.\d\.\d)' readme.txt)" >> $GITHUB_ENV
+          echo "base_change_date=$(grep -Pio -m 1 "(?<=#### (\d\.\d\.\d) )(\d\d\/\d\d\/\d\d\d\d)" readme.txt)" >> $GITHUB_ENV
+          echo "base_plugin_version=$(grep -Pio -m 1 "(?<=Version: )(\d\.\d\.\d)" wp-discourse.php)" >> $GITHUB_ENV
+          echo "base_constant_version=$(grep -Pio -m 1 "(?<=WPDISCOURSE_VERSION\'\, \')(\d\.\d\.\d)" wp-discourse.php)" >> $GITHUB_ENV
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - name: Install semver
+        run: npm install --include=dev
+
+      - name: Run checks
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const semver = require('semver');
+            const variables = [
+              'readme_version',
+              'change_version',
+              'change_date',
+              'plugin_version',
+              'constant_version'
+            ];
+            const headVersions = [];
+
+            variables.forEach(variable => {
+              let head_var = process.env[`head_${variable}`];
+              let base_var = process.env[`base_${variable}`];
+              let type = variable.split('_')[1];
+
+              if (type === 'version) {
+                if (semver.lte(head_var, base_var)) {
+                  core.setFailed(`Head ${variable} is less than or equal to base ${variable}.`);
+                }
+                headVersions.push(head_var);
+              }
+
+              if (type === 'date' && head_var.getTime() <= base_var.getTime()) {
+                core.setFailed(`Head ${variable} is older than or the same as base ${variable}.`);
+              }
+            });
+
+            if (!headVersions.every(hv => hv === headVersions[0])) {
+              core.setFailed('Head versions do not match.');
+            }

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -8,6 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     name: Metadata
     steps:
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          cache: 'npm'
+      - run: npm install --include=dev
+
       - name: Checkout head repository
         uses: actions/checkout@v2
 
@@ -31,13 +38,6 @@ jobs:
           echo "base_change_date=$(grep -Pio -m 1 "(?<=#### (\d\.\d\.\d) )(\d\d\/\d\d\/\d\d\d\d)" readme.txt)" >> $GITHUB_ENV
           echo "base_plugin_version=$(grep -Pio -m 1 "(?<=Version: )(\d\.\d\.\d)" wp-discourse.php)" >> $GITHUB_ENV
           echo "base_constant_version=$(grep -Pio -m 1 "(?<=WPDISCOURSE_VERSION\'\, \')(\d\.\d\.\d)" wp-discourse.php)" >> $GITHUB_ENV
-
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
-          cache: 'npm'
-      - run: npm install --include=dev
 
       - name: Run checks
         uses: actions/github-script@v5

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -53,19 +53,24 @@ jobs:
             const headVersions = [];
 
             variables.forEach(variable => {
-              let head_var = process.env[`head_${variable}`];
-              let base_var = process.env[`base_${variable}`];
+              let headVar = process.env[`head_${variable}`];
+              let baseVar = process.env[`base_${variable}`];
               let type = variable.split('_')[1];
 
               if (type === 'version') {
-                if (semver.lte(head_var, base_var)) {
+                if (semver.lte(headVar, baseVar)) {
                   core.setFailed(`Head ${variable} is less than or equal to base ${variable}.`);
                 }
-                headVersions.push(head_var);
+                headVersions.push(headVar);
               }
 
-              if (type === 'date' && head_var.getTime() <= base_var.getTime()) {
-                core.setFailed(`Head ${variable} is older than or the same as base ${variable}.`);
+              if (type === 'date') {
+                let headDate = new Date(headVar);
+                let baseDate = new Date(baseVar);
+
+                if (headDate.getTime() <= baseDate.getTime()) {
+                  core.setFailed(`Head ${variable} is older than or the same as base ${variable}.`);
+                }
               }
             });
 

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -36,9 +36,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14
-
-      - name: Install semver
-        run: npm install --include=dev
+          cache: 'npm'
+      - run: npm install --include=dev
 
       - name: Run checks
         uses: actions/github-script@v5

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -8,23 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Metadata
     steps:
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
-      - run: npm install --include=dev
-
-      - name: Checkout head repository
-        uses: actions/checkout@v2
-
-      - name: Store head versions
-        run: |
-          echo "head_readme_version=$(grep -Pio -m 1 '(?<=Stable tag: )(\d\.\d\.\d)' readme.txt)" >> $GITHUB_ENV
-          echo "head_change_version=$(grep -Pio -m 1 '(?<=#### )(\d\.\d\.\d)' readme.txt)" >> $GITHUB_ENV
-          echo "head_change_date=$(grep -Pio -m 1 "(?<=#### (\d\.\d\.\d) )(\d\d\/\d\d\/\d\d\d\d)" readme.txt)" >> $GITHUB_ENV
-          echo "head_plugin_version=$(grep -Pio -m 1 "(?<=Version: )(\d\.\d\.\d)" wp-discourse.php)" >> $GITHUB_ENV
-          echo "head_constant_version=$(grep -Pio -m 1 "(?<=WPDISCOURSE_VERSION\'\, \')(\d\.\d\.\d)" wp-discourse.php)" >> $GITHUB_ENV
-
       - name: Checkout base repository
         uses: actions/checkout@v2
         with:
@@ -37,6 +20,23 @@ jobs:
           echo "base_change_date=$(grep -Pio -m 1 "(?<=#### (\d\.\d\.\d) )(\d\d\/\d\d\/\d\d\d\d)" readme.txt)" >> $GITHUB_ENV
           echo "base_plugin_version=$(grep -Pio -m 1 "(?<=Version: )(\d\.\d\.\d)" wp-discourse.php)" >> $GITHUB_ENV
           echo "base_constant_version=$(grep -Pio -m 1 "(?<=WPDISCOURSE_VERSION\'\, \')(\d\.\d\.\d)" wp-discourse.php)" >> $GITHUB_ENV
+
+      - name: Checkout head repository
+        uses: actions/checkout@v2
+
+      - name: Store head versions
+        run: |
+          echo "head_readme_version=$(grep -Pio -m 1 '(?<=Stable tag: )(\d\.\d\.\d)' readme.txt)" >> $GITHUB_ENV
+          echo "head_change_version=$(grep -Pio -m 1 '(?<=#### )(\d\.\d\.\d)' readme.txt)" >> $GITHUB_ENV
+          echo "head_change_date=$(grep -Pio -m 1 "(?<=#### (\d\.\d\.\d) )(\d\d\/\d\d\/\d\d\d\d)" readme.txt)" >> $GITHUB_ENV
+          echo "head_plugin_version=$(grep -Pio -m 1 "(?<=Version: )(\d\.\d\.\d)" wp-discourse.php)" >> $GITHUB_ENV
+          echo "head_constant_version=$(grep -Pio -m 1 "(?<=WPDISCOURSE_VERSION\'\, \')(\d\.\d\.\d)" wp-discourse.php)" >> $GITHUB_ENV
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - run: npm install --include=dev
 
       - name: Run checks
         uses: actions/github-script@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: PHP ${{ matrix.php }}
+    name: Tests on PHP ${{ matrix.php }}
     strategy:
       matrix:
         include:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,53 +13,32 @@ jobs:
     strategy:
       matrix:
         include:
-          - php: "5.6"
-            sniff: true
-            test: false
-          - php: "7.0"
-            sniff: true
-            test: false
           - php: "7.4"
-            sniff: true
-            test: true
-          - php: "8.0"
-            sniff: false
-            test: false
     steps:
       - uses: actions/checkout@v2
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+
       - name: Install Composer
-        if: "${{ matrix.sniff || matrix.test }}"
         uses: ramsey/composer-install@v1
         with:
           dependency-versions: "highest"
           composer-options: "--ignore-platform-reqs"
+
       - name: Install PHPEnv
-        if: "${{ matrix.sniff || matrix.test }}"
         run: |
           git clone --depth 1 git://github.com/phpenv/phpenv.git ~/.phpenv
           export PATH="$HOME/.phpenv/bin:$PATH"
           phpenv rehash
-      - name: Syntax Check
-        run: |
-          find -L . -name '*.php' -not -path "./vendor/*" -print0 | xargs -0 -n 1 -P 4 php -l
-      - name: JSHint
-        if: "matrix.sniff"
-        run: |
-          sudo npm install -g jshint
-          wget https://develop.svn.wordpress.org/trunk/.jshintrc
-          jshint .
-      - name: WordPress Coding Standards
-        if: "matrix.sniff"
-        run: |
-          vendor/bin/phpcs -p -s -v -n .
+
       - name: PHPUnit
-        if: "matrix.test"
         run: |
           sudo /etc/init.d/mysql start
           bash bin/install-wp-tests.sh wordpress_test root 'root' localhost latest
           vendor/bin/phpunit
+
+      - name: PHPUnit Multisite
+        run: |
           vendor/bin/phpunit -c tests/phpunit/multisite.xml

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ wpcs/*
 
 *.sublime-workspace
 *.sublime-project
+
+node_modules

--- a/README.md
+++ b/README.md
@@ -97,12 +97,4 @@ For more details on template customization, see: [WP Discourse template customiz
 
 #### Contributing
 
-Before you start contributing or developing this plugin please read the documentation in ``docs/`` explaining how the plugin handles code formatting, linting, tests and using composer packages. If you have any questions about those process, please raise an issue on the repository.
-
-When you've read the docs, you're ready to start coding! Here's how to get started
-
-1. Fork this repo
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create a new pull request
+Before you start contributing or developing this plugin please read the documentation in ``docs/``, starting with [contributing.md](https://github.com/discourse/wp-discourse/blob/main/docs/contributing.md). If you have any questions about those process, please post in [#dev](https://meta.discourse.org/c/dev/7) for assistance.

--- a/docs/COMPOSER.md
+++ b/docs/COMPOSER.md
@@ -2,7 +2,7 @@
 
 WP Discourse uses [Composer](https://getcomposer.org) in the standard fashion, but there are a few things that are worth pointing out when developing this plugin and using composer packages in production.
 
-> Please note, this guide is intended for developers of this plugin. If you're using this plugin via composer, this does not apply to you. Use it as you normally would.
+> Please note, this guide is intended for developers of this plugin. If you're using this plugin via composer, this does not apply to you; see "Installation: With Composer" in the README.md instead.
 
 ### Adding Composer Packages For Production Use
 

--- a/docs/FORMATTING.md
+++ b/docs/FORMATTING.md
@@ -1,4 +1,4 @@
-### WP Discourse Code Formatting
+### WP Discourse Code Formatting Guide
 
 WP Discourse uses
 - [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) to handle code formatting (``phpcs``);

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,27 @@
+### WP Discourse Contribution Guidelines
+
+This is an overview guide for WP Discourse plugin development, pull requests and deployment.
+
+### Development
+
+Before starting development, make sure you read [composer.md](https://github.com/discourse/wp-discourse/blob/main/docs/composer.md), [formatting.md](https://github.com/discourse/wp-discourse/blob/main/docs/formatting.md) and [tests.md](https://github.com/discourse/wp-discourse/blob/main/docs/tests.md) to understand how each of those subjects are handled. If you feel those guides are not descriptive enough, or you're stuck with one of them, please post in [#dev](https://meta.discourse.org/c/dev/7) for assistance.
+
+All changes to the WP Discourse codebase need to come with accompanying PHPUnit tests. We recommend you use test-driven development, particularly if you're writing new features. All changes must also support the PHP versions the plugin supports, which are listed in the [formatting workflow](https://github.com/discourse/wp-discourse/blob/main/.github/workflows/formatting.yml), however the most common PHP version to work with locally is ``PHP 7.4``. Note that ``PHP 8.0`` introduces some new syntax that is incompatible with older versions.
+
+### Pull Requests
+
+All changes to the WP Discourse plugin are done via pull requests. The [formatting](https://github.com/discourse/wp-discourse/blob/main/.github/workflows/formatting.yml), [metadata](https://github.com/discourse/wp-discourse/blob/main/.github/workflows/metadata.yml) and [tests](https://github.com/discourse/wp-discourse/blob/main/.github/workflows/formatting.yml) workflows will be run against all pull requests. They will:
+
+- Check the syntax of ``.php`` files against the PHP versions we support.
+- Run PHPCS against all ``.php`` files, failing on errors.
+- Run JSHint against all ``.js`` files.
+- Run all of the PHPUnit tests (both standard and multisite).
+- Check that the all the version numbers have been increased and release notes have been added.
+
+#### Versioning and Release Notes
+
+All pull requests need to bump the version of the plugin; in most cases the ``PATCH``. All version increments need release notes in the readme.txt.
+
+### Deployment
+
+Once a pull request is ready and CI is passing, a Discourse staff member will need to review, approve and merge the PR. Once the PR is merged, the staff member will create a new git tag matching the new version of the Plugin. Creating the tag will trigger the [deploy](https://github.com/discourse/wp-discourse/blob/main/.github/workflows/deploy.yml) workflow which pushes the new version to wordpress.org.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,74 @@
+{
+  "name": "wp-discourse",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "GPL V2",
+      "devDependencies": {
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "wp-discourse",
+  "version": "1.0.0",
+  "repository": "git@github.com:discourse/wp-discourse.git",
+  "author": "Discourse",
+  "license": "GPL V2",
+  "devDependencies": {
+    "semver": "^7.3.5"
+  }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: discourse, forum, comments, sso
 Requires at least: 4.7
 Tested up to: 5.8
 Requires PHP: 5.6.0
-Stable tag: 2.3.6
+Stable tag: 2.3.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -122,6 +122,10 @@ To create a coherent top menu, see our tutorial on how to make a [Custom nav hea
 8. Configuring the plugin: the DiscourseConnect Client settings tab.
 
 == Changelog ==
+
+#### 2.3.7 12/07/2021
+
+- Update CI and developer documentation
 
 #### 2.3.6 12/06/2021
 

--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WP-Discourse
  * Description: Use Discourse as a community engine for your WordPress blog
- * Version: 2.3.6
+ * Version: 2.3.7
  * Author: Discourse
  * Text Domain: wp-discourse
  * Domain Path: /languages
@@ -34,7 +34,7 @@ define( 'WPDISCOURSE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WPDISCOURSE_URL', plugins_url( '', __FILE__ ) );
 define( 'MIN_WP_VERSION', '4.7' );
 define( 'MIN_PHP_VERSION', '5.6.0' );
-define( 'WPDISCOURSE_VERSION', '2.3.6' );
+define( 'WPDISCOURSE_VERSION', '2.3.7' );
 
 require_once WPDISCOURSE_PATH . 'lib/plugin-utilities.php';
 require_once WPDISCOURSE_PATH . 'lib/template-functions.php';


### PR DESCRIPTION
@scossar This does PR does the following:

- Workflows broken into seperate files: deploy, formatting, metadata and tests.
- Added new metadata workflow that checks if the all the versions have been properly incremented.

See the metadata checks failing here

https://github.com/discourse/wp-discourse/runs/4443780311?check_suite_focus=true

```
Error: Head readme_version is less than or equal to base readme_version.
Error: Head change_version is less than or equal to base change_version.
Error: Head change_date is older than or the same as base change_date.
Error: Head plugin_version is less than or equal to base plugin_version.
Error: Head constant_version is less than or equal to base constant_version.
```

See the metadata checks passing here (after I incremented the versions [here](https://github.com/discourse/wp-discourse/pull/430/commits/42a94709c2a86f3cc48e1f65e308afae7f7972e0)).

https://github.com/discourse/wp-discourse/runs/4443884590?check_suite_focus=true

