### PR TITLE
Two Four Nine

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,9 +12,8 @@ jobs:
     name: Tests on PHP ${{ matrix.php }}
     strategy:
       matrix:
-        include:
-          - php: '7.4'
-          - wordpress: ['5.1.2', 'latest']
+        php: '7.4'
+        wordpress: ['5.1.2', 'latest']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         include:
           - php: '7.4'
+          - wordpress: ['5.1.2', 'latest']
 
     steps:
       - uses: actions/checkout@v3
@@ -31,7 +32,7 @@ jobs:
       - name: PHPUnit
         run: |
           sudo /etc/init.d/mysql start
-          bash bin/install-wp-tests.sh wordpress_test root 'root' localhost latest
+          bash bin/install-wp-tests.sh wordpress_test root 'root' localhost ${{ matrix.wordpress }}
           vendor/bin/phpunit
 
       - name: PHPUnit Multisite

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     name: Tests on PHP ${{ matrix.php }}
     strategy:
       matrix:
-        php: '7.4'
+        php: ['7.4']
         wordpress: ['5.1.2', 'latest']
 
     steps:

--- a/blocks/comments/comments.php
+++ b/blocks/comments/comments.php
@@ -43,11 +43,13 @@ function render_block_wpdc_comments( $attributes, $content, $block ) {
  * Registers the `wp-discourse/comments` block on the server.
  */
 function register_wpdc_blocks() {
-	register_block_type_from_metadata(
-		WPDISCOURSE_PATH . 'blocks/comments/build/block.json',
-		array(
-			'render_callback' => 'render_block_wpdc_comments',
-		)
-	);
+  if ( version_compare( get_bloginfo('version'), '5.5', '>=' ) ) {
+    register_block_type_from_metadata(
+  		WPDISCOURSE_PATH . 'blocks/comments/build/block.json',
+  		array(
+  			'render_callback' => 'render_block_wpdc_comments',
+  		)
+  	);
+  }
 }
 add_action( 'init', 'register_wpdc_blocks' );

--- a/blocks/comments/comments.php
+++ b/blocks/comments/comments.php
@@ -43,13 +43,13 @@ function render_block_wpdc_comments( $attributes, $content, $block ) {
  * Registers the `wp-discourse/comments` block on the server.
  */
 function register_wpdc_blocks() {
-  if ( version_compare( get_bloginfo('version'), '5.5', '>=' ) ) {
-    register_block_type_from_metadata(
+  if ( version_compare( get_bloginfo( 'version' ), '5.5', '>=' ) ) {
+		register_block_type_from_metadata(
   		WPDISCOURSE_PATH . 'blocks/comments/build/block.json',
   		array(
   			'render_callback' => 'render_block_wpdc_comments',
   		)
-  	);
+		  );
   }
 }
 add_action( 'init', 'register_wpdc_blocks' );

--- a/lib/sso-provider/discourse-sso.php
+++ b/lib/sso-provider/discourse-sso.php
@@ -234,8 +234,8 @@ class DiscourseSSO extends DiscourseBase {
 			$user_id = get_current_user_id();
 			wp_logout();
 
-			if ( version_compare( get_bloginfo('version'), '5.3', '<' ) ) {
-				// See https://core.trac.wordpress.org/ticket/35488
+			if ( version_compare( get_bloginfo( 'version' ), '5.3', '<' ) ) {
+				// See https://core.trac.wordpress.org/ticket/35488.
 				wp_set_current_user( 0 );
 			}
 

--- a/lib/sso-provider/discourse-sso.php
+++ b/lib/sso-provider/discourse-sso.php
@@ -234,6 +234,11 @@ class DiscourseSSO extends DiscourseBase {
 			$user_id = get_current_user_id();
 			wp_logout();
 
+			if ( version_compare( get_bloginfo('version'), '5.3', '<' ) ) {
+				// See https://core.trac.wordpress.org/ticket/35488
+				wp_set_current_user( 0 );
+			}
+
 			if ( $user_id && ! empty( $this->options['verbose-sso-logs'] ) ) {
 				$this->logger->info( 'handle_logout_request.success', array( 'user_id' => $user_id ) );
 			}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,6 +6,7 @@
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
+	convertDeprecationsToExceptions="false"
 	>
 	<testsuites>
 		<testsuite name="unit">

--- a/readme.txt
+++ b/readme.txt
@@ -129,7 +129,7 @@ To create a coherent top menu, see our tutorial on how to make a [Custom nav hea
 - Fix compatibility with S3 uploads plugin.
 - Fix usage of get_the_excerpt filter.
 - Fixed HTML of avatars in quotes in comments.
-- Verified backwards compatibility for WP > 5.1.2.
+- Verified backwards compatibility for WP > 5.1
 
 #### 2.4.8 12/27/2022
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === WP Discourse ===
 Contributors: scossar, cdck, angusmcleod, samsaffron, techapj
 Tags: discourse, forum, comments, sso
-Requires at least: 4.7
+Requires at least: 5.1
 Tested up to: 6.1
-Requires PHP: 5.6.0
-Stable tag: 2.4.8
+Requires PHP: 5.6
+Stable tag: 2.4.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -122,6 +122,14 @@ To create a coherent top menu, see our tutorial on how to make a [Custom nav hea
 8. Configuring the plugin: the DiscourseConnect Client settings tab.
 
 == Changelog ==
+
+#### 2.4.9 02/16/2023
+
+- Fix optional parameter handling in get_discourse_comments.
+- Fix compatibility with S3 uploads plugin.
+- Fix usage of get_the_excerpt filter.
+- Fixed HTML of avatars in quotes in comments.
+- Verified backwards compatibility for WP > 5.1.2.
 
 #### 2.4.8 12/27/2022
 

--- a/tests/phpunit/multisite.xml
+++ b/tests/phpunit/multisite.xml
@@ -6,6 +6,7 @@
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
+	convertDeprecationsToExceptions="false"
 	>
 	<php>
      <const name="WP_TESTS_MULTISITE" value="1" />

--- a/tests/phpunit/test-discourse-publish.php
+++ b/tests/phpunit/test-discourse-publish.php
@@ -580,8 +580,8 @@ class DiscoursePublishTest extends UnitTest {
      */
     public function test_exclude_tags_with_exclusionary_tag() {
         if ( version_compare( get_bloginfo( 'version' ), '5.6', '<' ) ) {
-          $this->markTestSkipped(
-            'Not supported on wordpress version.'
+        $this->markTestSkipped(
+            'Not supported on WordPress version.'
           );
         }
 

--- a/tests/phpunit/test-discourse-publish.php
+++ b/tests/phpunit/test-discourse-publish.php
@@ -579,6 +579,12 @@ class DiscoursePublishTest extends UnitTest {
      * Exclude_tags prevents publication if excluded tag is present
      */
     public function test_exclude_tags_with_exclusionary_tag() {
+        if ( version_compare( get_bloginfo( 'version' ), '5.6', '<' ) ) {
+          $this->markTestSkipped(
+            'Not supported on wordpress version.'
+          );
+        }
+
         // Create the exclusionary tag
         $excluded_term = term_exists( 'dont_publish', 'post_tag' );
         if ( ! $excluded_term ) {

--- a/tests/phpunit/test-sso-client.php
+++ b/tests/phpunit/test-sso-client.php
@@ -20,10 +20,10 @@ class SSOClientTest extends UnitTest {
 		parent::initialize_shared_variables();
 		wp_logout();
 
-    if ( version_compare( get_bloginfo('version'), '5.3', '<' ) ) {
+		if ( version_compare( get_bloginfo( 'version' ), '5.3', '<' ) ) {
 			// See https://core.trac.wordpress.org/ticket/35488
 			wp_set_current_user( 0 );
-		}
+			}
   }
 
   public function setUp() {
@@ -69,10 +69,10 @@ class SSOClientTest extends UnitTest {
 		delete_metadata( 'user', null, 'discourse_sso_user_id', null, true );
 		wp_logout();
 
-    if ( version_compare( get_bloginfo('version'), '5.3', '<' ) ) {
+		if ( version_compare( get_bloginfo( 'version' ), '5.3', '<' ) ) {
 			// See https://core.trac.wordpress.org/ticket/35488
 			wp_set_current_user( 0 );
-		}
+			}
   }
 
   /**

--- a/tests/phpunit/test-sso-client.php
+++ b/tests/phpunit/test-sso-client.php
@@ -19,6 +19,11 @@ class SSOClientTest extends UnitTest {
   public static function setUpBeforeClass() {
 		parent::initialize_shared_variables();
 		wp_logout();
+
+    if ( version_compare( get_bloginfo('version'), '5.3', '<' ) ) {
+			// See https://core.trac.wordpress.org/ticket/35488
+			wp_set_current_user( 0 );
+		}
   }
 
   public function setUp() {
@@ -63,6 +68,11 @@ class SSOClientTest extends UnitTest {
 		delete_metadata( 'user', null, 'discourse_username', null, true );
 		delete_metadata( 'user', null, 'discourse_sso_user_id', null, true );
 		wp_logout();
+
+    if ( version_compare( get_bloginfo('version'), '5.3', '<' ) ) {
+			// See https://core.trac.wordpress.org/ticket/35488
+			wp_set_current_user( 0 );
+		}
   }
 
   /**

--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -2,7 +2,9 @@
 /**
  * Plugin Name: WP-Discourse
  * Description: Use Discourse as a community engine for your WordPress blog
- * Version: 2.4.8
+ * Version: 2.4.9
+ * Requires at least: 5.1
+ * Requires PHP: 5.6
  * Author: Discourse
  * Text Domain: wp-discourse
  * Domain Path: /languages
@@ -34,7 +36,7 @@ define( 'WPDISCOURSE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WPDISCOURSE_URL', plugins_url( '', __FILE__ ) );
 define( 'MIN_WP_VERSION', '4.7' );
 define( 'MIN_PHP_VERSION', '5.6.0' );
-define( 'WPDISCOURSE_VERSION', '2.4.8' );
+define( 'WPDISCOURSE_VERSION', '2.4.9' );
 define( 'WPDISCOURSE_LOGO_URL', WPDISCOURSE_PATH . 'assets/icon.svg' );
 $base64 = base64_encode( file_get_contents( WPDISCOURSE_LOGO_URL ) );
 define( 'WPDISCOURSE_LOGO', "data:image/svg+xml;base64,$base64" );


### PR DESCRIPTION
- Fix optional parameter handling in get_discourse_comments.
- Fix compatibility with S3 uploads plugin.
- Fix usage of get_the_excerpt filter.
- Fixed HTML of avatars in quotes in comments.
- Verified backwards compatibility for WP > 5.1.