### PR TITLE
DEV: Refactor publish_post_after_save function

### DIFF
--- a/lib/discourse-publish.php
+++ b/lib/discourse-publish.php
@@ -48,7 +48,7 @@ class DiscoursePublish extends DiscourseBase {
 	 * @access public
 	 * @var bool
 	 */
-	public bool $force_publish_allowed = false;
+	public $force_publish_allowed = false;
 
 
 

--- a/lib/discourse-publish.php
+++ b/lib/discourse-publish.php
@@ -86,16 +86,16 @@ class DiscoursePublish extends DiscourseBase {
 		$post_marked_to_be_published   = $this->dc_get_post_meta( $post_id, 'publish_to_discourse', true );
 		$publish_new_post_to_discourse = ( $post_marked_to_be_published || $post_should_be_auto_published ) && ! $post_already_published;
 		$topic_should_be_updated       = $this->dc_get_post_meta( $post_id, 'update_discourse_topic', true );
-		$publish_to_discourse          = $publish_new_post_to_discourse || $topic_should_be_updated;
-		$publish_to_discourse          = apply_filters( 'wpdc_publish_after_save', $publish_to_discourse, $post_id, $post );
-
-		$force_publish_post = $this->force_publish_post( $post );
+		$force_publish_post            = $this->force_publish_post( $post );
 		if ( $force_publish_post ) {
 			// All force published posts are published to the default publish-category.
 			update_post_meta( $post_id, 'publish_post_category', intval( $this->options['publish-category'] ) );
 		}
 
-		if ( $publish_to_discourse || $force_publish_post ) {
+		$publish_to_discourse = $publish_new_post_to_discourse || $topic_should_be_updated || $force_publish_post;
+		$publish_to_discourse = apply_filters( 'wpdc_publish_after_save', $publish_to_discourse, $post_id, $post );
+
+		if ( $publish_to_discourse ) {
 			$title = $this->sanitize_title( $post->post_title );
 			$title = apply_filters( 'wpdc_publish_format_title', $title, $post_id );
 			// Clear existing publishing errors.

--- a/tests/phpunit/test-discourse-publish.php
+++ b/tests/phpunit/test-discourse-publish.php
@@ -788,7 +788,7 @@ class DiscoursePublishTest extends UnitTest {
 		// Set 'post_date' to 7 days in the past.
 		$post_atts                                       = self::$post_atts;
 		$post_atts['meta_input']['publish_to_discourse'] = 0;
-		$post_atts['post_date']                          = date( 'Y-m-d H:i:s', strtotime( '-7 days' ) );
+		$post_atts['post_date']                          = gmdate( 'Y-m-d H:i:s', strtotime( '-7 days' ) );
 		$post_id = wp_insert_post( $post_atts, false, false );
 
 		// Trigger the publish_post_after_save method


### PR DESCRIPTION
Refactors the `publish_post_after_save` function. It's logic has been broken out into the following protected functions:

- `exclude_post`
- `auto_publish`
- `force_publish_post`

I've included the new protected functions directly under the `publish_post_after_save` function. This was done for readability reasons, but possibly they should be moved lower down in the file.

Some variables have been renamed in the attempt to make it clear at first glance what they are being used for.

None of the underlying logic has been changed.

This PR also removes the unused `post_id` argument from the `has_excluded_tag` function and fixes an issue where `$post_id` was being passed instead of `$post` to that function from the `xmlrpc_publish_post_to_discourse` function.

Possibly some similar changes should be made to the `sync_to_discourse_work` function. 