### PR TITLE
DEV: Refactor xmlrpc_publish_post_to_discourse

### DIFF
--- a/lib/discourse-publish.php
+++ b/lib/discourse-publish.php
@@ -103,8 +103,7 @@ class DiscoursePublish extends DiscourseBase {
 		if ( $publish_to_discourse ) {
 			// Clear existing publishing errors.
 			delete_post_meta( $post_id, 'wpdc_publishing_error' );
-			$title = $post->post_title;
-			$this->sync_to_discourse( $post_id, $title, $post->post_content );
+			$this->sync_to_discourse( $post_id, $post->post_title, $post->post_content );
 		}
 		return null;
 	}

--- a/lib/discourse-publish.php
+++ b/lib/discourse-publish.php
@@ -103,7 +103,7 @@ class DiscoursePublish extends DiscourseBase {
 		if ( $publish_to_discourse ) {
 			// Clear existing publishing errors.
 			delete_post_meta( $post_id, 'wpdc_publishing_error' );
-			$title = $post->title;
+			$title = $post->post_title;
 			$this->sync_to_discourse( $post_id, $title, $post->post_content );
 		}
 		return null;

--- a/lib/email-notification.php
+++ b/lib/email-notification.php
@@ -42,6 +42,8 @@ class EmailNotification {
 	 *
 	 * @param object $post $discourse_post The post where the failure occurred.
 	 * @param array  $args Optional arguments for the function. The 'location' argument can be used to indicate where the failure occurred.
+	 *
+	 * @return void|bool
 	 */
 	public function publish_failure_notification( $post, $args ) {
 		$post_id  = $post->ID;
@@ -110,7 +112,11 @@ class EmailNotification {
 			// translators: Discourse publishing email. Placeholder: Discourse support URL.
 			$message .= sprintf( __( '<%1$s>', 'wp-discourse' ), esc_url( $support_url ) ) . "\r\n";
 			// translators: Discourse publishing email. Placeholder: blogname, email message.
-			wp_mail( $publish_failure_email, sprintf( __( '[%s] Discourse Publishing Failure' ), $blogname ), $message );
+			$success = wp_mail( $publish_failure_email, sprintf( __( '[%s] Discourse Publishing Failure' ), $blogname ), $message );
+
+			return $success;
 		}// End if().
+
+		return false;
 	}
 }

--- a/tests/phpunit/test-discourse-publish.php
+++ b/tests/phpunit/test-discourse-publish.php
@@ -26,6 +26,12 @@ class DiscoursePublishTest extends UnitTest {
 	 */
 	protected $publish;
 
+	/**
+	 * A partial mock instance of EmailNotification.
+	 *
+	 * @access protected
+	 * @var \Mockery\Mock
+	 */
 	protected $email_notifier;
 
 	/**
@@ -855,6 +861,10 @@ class DiscoursePublishTest extends UnitTest {
 		return true;
 	}
 
+	/**
+	 * Posts can only be published via XMLRPC by hooking into the wp_discourse_before_xmlrpc_publish filter with a function
+	 * that returns `true`.
+	 */
 	public function test_wp_discourse_before_xmlrpc_publish_filter() {
 		$body              = $this->mock_remote_post_success( 'post_create', 'POST' );
 		$discourse_post_id = $body->id;
@@ -881,6 +891,9 @@ class DiscoursePublishTest extends UnitTest {
 		remove_filter( 'wp_discourse_before_xmlrpc_publish', array( $this, 'override_wp_discourse_before_xmlrpc_publish' ), 10, 1 );
 	}
 
+	/**
+	 * When the auto-publish option is enabled, posts published via XMLRPC will trigger a publish_failure_notification.
+	 */
 	public function test_xmlrpc_publish_failure_notification() {
 		$plugin_options = self::$plugin_options;
 		// The  xmlrpc failure notification will only be triggered if the auto-publish option is set.

--- a/tests/phpunit/test-discourse-publish.php
+++ b/tests/phpunit/test-discourse-publish.php
@@ -26,6 +26,8 @@ class DiscoursePublishTest extends UnitTest {
 	 */
 	protected $publish;
 
+	protected $email_notifier;
+
 	/**
 	 * Setup test class
 	 */
@@ -40,9 +42,9 @@ class DiscoursePublishTest extends UnitTest {
 	 */
 	public function setUp() {
 		parent::setUp();
-
-		$register_actions = false;
-		$this->publish    = new DiscoursePublish( new EmailNotification(), $register_actions );
+		$register_actions     = false;
+		$this->email_notifier = \Mockery::mock( EmailNotification::class )->makePartial();
+		$this->publish        = new DiscoursePublish( $this->email_notifier, $register_actions );
 		$this->publish->setup_options( self::$plugin_options );
 		$this->publish->setup_logger();
 	}
@@ -726,8 +728,9 @@ class DiscoursePublishTest extends UnitTest {
 	 */
 	public function test_force_publish_allowed_property() {
 		// Enable the force-publish option, but don't override default value of the force_publish_allowed property.
-		self::$plugin_options['force-publish'] = 1;
-		$this->publish->setup_options( self::$plugin_options );
+		$plugin_options                  = self::$plugin_options;
+		$plugin_options['force-publish'] = 1;
+		$this->publish->setup_options( $plugin_options );
 
 		// Set up a response body for creating a new post.
 		$body              = $this->mock_remote_post_success( 'post_create', 'POST' );
@@ -765,8 +768,9 @@ class DiscoursePublishTest extends UnitTest {
 	public function test_force_publish_option() {
 		$this->publish->force_publish_allowed = true;
 		// Explicitly disable the force-publish option.
-		self::$plugin_options['force-publish'] = 0;
-		$this->publish->setup_options( self::$plugin_options );
+		$plugin_options                  = self::$plugin_options;
+		$plugin_options['force-publish'] = 0;
+		$this->publish->setup_options( $plugin_options );
 
 		// Set up a response body for creating a new post.
 		$body              = $this->mock_remote_post_success( 'post_create', 'POST' );
@@ -785,8 +789,9 @@ class DiscoursePublishTest extends UnitTest {
 		$this->assertEmpty( get_post_meta( $post_id, 'discourse_post_id', true ) );
 
 		// Enable the force-publish option.
-		self::$plugin_options['force-publish'] = 1;
-		$this->publish->setup_options( self::$plugin_options );
+		$plugin_options                  = self::$plugin_options;
+		$plugin_options['force-publish'] = 1;
+		$this->publish->setup_options( $plugin_options );
 
 		// Trigger the publish_post_after_save method.
 		$this->publish->publish_post_after_save( $post_id, $post );
@@ -804,10 +809,11 @@ class DiscoursePublishTest extends UnitTest {
 	 */
 	public function test_force_publish_max_age_prevents_older_posts_from_being_published() {
 		$this->publish->force_publish_allowed = true;
-		self::$plugin_options['force-publish'] = 1;
+		$plugin_options                       = self::$plugin_options;
+		$plugin_options['force-publish']      = 1;
 		// Don't publish posts that were created greater than 2 days ago.
-		self::$plugin_options['force-publish-max-age'] = 2;
-		$this->publish->setup_options( self::$plugin_options );
+		$plugin_options['force-publish-max-age'] = 2;
+		$this->publish->setup_options( $plugin_options );
 
 		// Set up a response hook for creating a new post.
 		$body              = $this->mock_remote_post_success( 'post_create', 'POST' );
@@ -828,8 +834,8 @@ class DiscoursePublishTest extends UnitTest {
 		$this->assertEmpty( get_post_meta( $post_id, 'discourse_post_id', true ) );
 
 		// Change force-publish-max-age to 20.
-		self::$plugin_options['force-publish-max-age'] = 20;
-		$this->publish->setup_options( self::$plugin_options );
+		$plugin_options['force-publish-max-age'] = 20;
+		$this->publish->setup_options( $plugin_options );
 
 		// Trigger the publish_post_after_save method.
 		$this->publish->publish_post_after_save( $post_id, $post );
@@ -837,6 +843,56 @@ class DiscoursePublishTest extends UnitTest {
 		// Ensure that publication has occurred.
 		$this->assertEquals( get_post_meta( $post_id, 'discourse_post_id', true ), $discourse_post_id );
 		$this->assertEquals( get_post_meta( $post_id, 'wpdc_publishing_response', true ), 'success' );
+
+		// Cleanup.
+		wp_delete_post( $post_id );
+	}
+
+	/**
+	 * Used in test_wp_discourse_before_xmlrpc_publish_filter.
+	 */
+	public function override_wp_discourse_before_xmlrpc_publish( $publish_to_discourse ) {
+		return true;
+	}
+
+	public function test_wp_discourse_before_xmlrpc_publish_filter() {
+		$body              = $this->mock_remote_post_success( 'post_create', 'POST' );
+		$discourse_post_id = $body->id;
+		// Note: `self::$post_atts['meta_input']['publish_to_discourse'] === 1`.
+		$post_atts = self::$post_atts;
+		$post_id   = wp_insert_post( $post_atts, false, false );
+
+		// Call xmlrpc_publish_post_to_discourse without hooking into the wp_discourse_before_xmlrpc_publish filter.
+		$this->publish->xmlrpc_publish_post_to_discourse( $post_id );
+
+		// Ensure that publication has not occurred.
+		$this->assertEmpty( get_post_meta( $post_id, 'discourse_post_id', true ) );
+
+		// Hook into the filter to allow for xmlrpc publishing.
+		add_filter( 'wp_discourse_before_xmlrpc_publish', array( $this, 'override_wp_discourse_before_xmlrpc_publish' ), 10, 1 );
+
+		$this->publish->xmlrpc_publish_post_to_discourse( $post_id );
+
+		// Ensure that publication has occurred.
+		$this->assertEquals( get_post_meta( $post_id, 'discourse_post_id', true ), $discourse_post_id );
+
+		// Cleanup.
+		wp_delete_post( $post_id );
+		remove_filter( 'wp_discourse_before_xmlrpc_publish', array( $this, 'override_wp_discourse_before_xmlrpc_publish' ), 10, 1 );
+	}
+
+	public function test_xmlrpc_publish_failure_notification() {
+		$plugin_options = self::$plugin_options;
+		// The  xmlrpc failure notification will only be triggered if the auto-publish option is set.
+		$plugin_options['auto-publish'] = 1;
+		$this->publish->setup_options( $plugin_options );
+
+		$post_atts = self::$post_atts;
+		$post_id   = wp_insert_post( $post_atts, false, false );
+
+		$this->email_notifier->shouldReceive( 'publish_failure_notification' )->withSomeOfArgs( array( 'location' => 'after_xmlrpc_publish' ) )->andReturn( true );
+
+		$this->assertTrue( $this->publish->xmlrpc_publish_post_to_discourse( $post_id ) );
 
 		// Cleanup.
 		wp_delete_post( $post_id );

--- a/tests/phpunit/test-discourse-publish.php
+++ b/tests/phpunit/test-discourse-publish.php
@@ -855,13 +855,6 @@ class DiscoursePublishTest extends UnitTest {
 	}
 
 	/**
-	 * Used in test_wp_discourse_before_xmlrpc_publish_filter.
-	 */
-	public function override_wp_discourse_before_xmlrpc_publish( $publish_to_discourse ) {
-		return true;
-	}
-
-	/**
 	 * Posts can only be published via XMLRPC by hooking into the wp_discourse_before_xmlrpc_publish filter with a function
 	 * that returns `true`.
 	 */
@@ -879,7 +872,7 @@ class DiscoursePublishTest extends UnitTest {
 		$this->assertEmpty( get_post_meta( $post_id, 'discourse_post_id', true ) );
 
 		// Hook into the filter to allow for xmlrpc publishing.
-		add_filter( 'wp_discourse_before_xmlrpc_publish', array( $this, 'override_wp_discourse_before_xmlrpc_publish' ), 10, 1 );
+		add_filter( 'wp_discourse_before_xmlrpc_publish', '__return_true' );
 
 		$this->publish->xmlrpc_publish_post_to_discourse( $post_id );
 
@@ -888,7 +881,7 @@ class DiscoursePublishTest extends UnitTest {
 
 		// Cleanup.
 		wp_delete_post( $post_id );
-		remove_filter( 'wp_discourse_before_xmlrpc_publish', array( $this, 'override_wp_discourse_before_xmlrpc_publish' ), 10, 1 );
+		remove_filter( 'wp_discourse_before_xmlrpc_publish', '__return_true' );
 	}
 
 	/**


### PR DESCRIPTION
Attempts to improve the `xmlrpc_publish_post_to_discourse` method. That method exists for historical reasons. I'm reluctant to remove it entirely, but I suspect that it's not being used on any sites.

This PR also:

- removes the call from `publish_post_after_save` to `update_post_meta( $post_id, 'publish_post_category', intval( $this->options['publish-category'] ) );` for force published posts. That is already being handled in the `sync_to_discourse_work` method.
- moves the call to `sanitize_title( $title )` from `publish_post_after_save` to the  `sync_to_discourse_work` method
- adds a boolean return value to `publish_failure_notification` to allow that method to be easily tested
- changes the EmailNotification object that's used in the DiscoursePublishTest setUp method so that it's a partial mock (`$this->email_notifier = \Mockery::mock( EmailNotification::class )->makePartial();`)
- updates the tests I've added to DiscoursePublishTest to avoid overwriting `self::$plugin_options` for subsequent tests (there are still tests in this class that have that issue. I can update them.)

Todo:

- add doc comment to DiscoursePublishTest `email_notifier` property
- ...

