### PR TITLE
Handle PHP deprecations

### DIFF
--- a/lib/discourse.php
+++ b/lib/discourse.php
@@ -222,7 +222,7 @@ class Discourse {
 				$saved_values   = get_option( 'discourse_configurable_text' );
 				$default_values = $this->discourse_configurable_text;
 				$merged_values  = array_merge( $default_values, $saved_values );
-				array_walk( $merged_values, 'self::register_text_translations' );
+				array_walk( $merged_values, self::class . '::register_text_translations' );
 				update_option( $group_name, $merged_values );
 			} else {
 				add_option( $group_name, $this->$group_name );

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/phpunit/bootstrap.php" backupGlobals="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  bootstrap="tests/phpunit/bootstrap.php"
+  colors="true"
+  convertErrorsToExceptions="true"
+  convertNoticesToExceptions="true"
+  convertWarningsToExceptions="true"
+  convertDeprecationsToExceptions="true"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd">
   <coverage processUncoveredFiles="true">
     <include>
       <directory suffix=".php">lib</directory>

--- a/tests/phpunit/multisite.xml
+++ b/tests/phpunit/multisite.xml
@@ -1,25 +1,12 @@
 <?xml version="1.0"?>
-<phpunit
-	bootstrap="bootstrap.php"
-	backupGlobals="false"
-	colors="true"
-	convertErrorsToExceptions="true"
-	convertNoticesToExceptions="true"
-	convertWarningsToExceptions="true"
-	convertDeprecationsToExceptions="false"
-	>
-	<php>
-     <const name="WP_TESTS_MULTISITE" value="1" />
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="bootstrap.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage/>
+  <php>
+    <const name="WP_TESTS_MULTISITE" value="1"/>
   </php>
-	<testsuites>
-		<testsuite name="multisite">
-			<directory prefix="test-" suffix=".php">multisite/</directory>
-		</testsuite>
-	</testsuites>
-	<filter>
-	  <whitelist processUncoveredFilesFromWhitelist="true">
-			<file>lib/discourse-publish.php</file>
-			<file>lib/sync-discourse-topic.php</file>
-	  </whitelist>
-	</filter>
+  <testsuites>
+    <testsuite name="multisite">
+      <directory prefix="test-" suffix=".php">multisite/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
See further https://meta.discourse.org/t/problem-with-use-of-self-in-callables-is-deprecated-in-wp-discourse/297543