### PR TITLE
Two Five Two

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: discourse, forum, comments, sso
 Requires at least: 5.1
 Tested up to: 6.4
 Requires PHP: 5.6
-Stable tag: 2.5.1
+Stable tag: 2.5.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -122,6 +122,12 @@ To create a coherent top menu, see our tutorial on how to make a [Custom nav hea
 8. Configuring the plugin: the DiscourseConnect Client settings tab.
 
 == Changelog ==
+
+#### 2.5.2 08/04/2024
+
+- Add a 'Disable user creation' setting for the DiscourseConnect Client.
+- Various package updates, deprecations and minor fixes.
+- Convert HTML entites in titles before sending to Discourse.
 
 #### 2.5.1 25/01/2024
 

--- a/wp-discourse.php
+++ b/wp-discourse.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WP-Discourse
  * Description: Use Discourse as a community engine for your WordPress blog
- * Version: 2.5.1
+ * Version: 2.5.2
  * Requires at least: 5.1
  * Requires PHP: 5.6
  * Author: Discourse
@@ -36,7 +36,7 @@ define( 'WPDISCOURSE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WPDISCOURSE_URL', plugins_url( '', __FILE__ ) );
 define( 'MIN_WP_VERSION', '4.7' );
 define( 'MIN_PHP_VERSION', '5.6.0' );
-define( 'WPDISCOURSE_VERSION', '2.5.1' );
+define( 'WPDISCOURSE_VERSION', '2.5.2' );
 define( 'WPDISCOURSE_LOGO_URL', WPDISCOURSE_PATH . 'assets/icon.svg' );
 $base64 = base64_encode( file_get_contents( WPDISCOURSE_LOGO_URL ) );
 define( 'WPDISCOURSE_LOGO', "data:image/svg+xml;base64,$base64" );


### PR DESCRIPTION
- Add a 'Disable user creation' setting for the DiscourseConnect Client.
- Various package updates, deprecations and minor fixes.
- Convert HTML entites in titles before sending to Discourse.

Live on https://wp-discourse.pavilion.tech/