### PR TITLE
Don't require existing wp comments to show wp comments with setting

### DIFF
--- a/lib/discourse-comment.php
+++ b/lib/discourse-comment.php
@@ -318,10 +318,7 @@ class DiscourseComment extends DiscourseBase {
 				break;
 		}
 
-		// Use $post->comment_count because get_comments_number will return the Discourse comments
-		// number for posts that are published to Discourse.
-		$num_wp_comments = $post->comment_count;
-		if ( empty( $this->options['show-existing-comments'] ) || 0 === intval( $num_wp_comments ) ) {
+		if ( empty( $this->options['show-existing-comments'] ) ) {
 			echo wp_kses_post( $discourse_comments );
 
 			return WPDISCOURSE_PATH . 'templates/blank.php';


### PR DESCRIPTION
See https://meta.discourse.org/t/using-wordpress-comments-alongside-discourse/312786