### PR TITLE
Only load comments if we have a post id

### DIFF
--- a/js/load-comments.js
+++ b/js/load-comments.js
@@ -9,8 +9,12 @@
 	$( document ).ready(
 		function() {
 			var commentsURL  = wpdc.commentsURL,
-				$commentArea = $( '#wpdc-comments' ),
+      $commentArea = $( '#wpdc-comments' ),
 				postId       = $commentArea.data( 'post-id' );
+
+      if (!postId) {
+        return;
+      }
 
 			$.ajax(
 				{


### PR DESCRIPTION
See https://meta.discourse.org/t/load-comments-w-ajax-enabled-brings-thousands-of-post-id-undefined-visitor-requests/382435